### PR TITLE
Rechtschreibfehler ausgebessert

### DIFF
--- a/bogenliga/src/assets/i18n/de.json
+++ b/bogenliga/src/assets/i18n/de.json
@@ -783,12 +783,12 @@
           "DESCRIPTION": "Möchten sie die Mannschaft trotzdem hinzufügen?"
         },
         "SAVE_FAILURE": {
-          "TITLE": "Fehler beim aktualisieren",
-          "DESCRIPTION": "Sportleiter hat keine Berechtigung über den ausgewählten Verein oder die Zielregion."
+          "TITLE": "Fehler beim Aktualisieren",
+          "DESCRIPTION": "Sportleiter hat keine Berechtigung über den Ausgewählten Verein oder die Zielregion."
         },
         "NO_LICENSE": {
           "TITLE": "Fehler beim Download",
-          "DESCRIPTION": "Der Lizenzenübersicht konnte nicht heruntergeladen werden, da eine oder mehreren Lizenzen nicht vorhanden sind."
+          "DESCRIPTION": "Der Lizenzenübersicht konnte nicht heruntergeladen werden, da eine oder mehrere Lizenzen nicht vorhanden sind."
         }
       }
     },
@@ -974,7 +974,7 @@
         },
         "OVERUSED": {
           "TITLE": "Fehler",
-          "DESCRIPTION": "Schütze kann dieser Mannschaft nicht hinzugefügt werden, da er schon in zuvielen Mannschaften eingesetzt wurde, bzw. in einer höheren Liga schon eingesetzt wurde."
+          "DESCRIPTION": "Schütze kann dieser Mannschaft nicht hinzugefügt werden, da er schon in zu vielen Mannschaften eingesetzt wurde, bzw. in einer höheren Liga schon eingesetzt wurde."
         },
         "NOWETTKAEMPFE": {
           "TITLE": "Lizenz konnte nicht geprüft werden.",

--- a/bogenliga/src/assets/i18n/de.json
+++ b/bogenliga/src/assets/i18n/de.json
@@ -784,7 +784,7 @@
         },
         "SAVE_FAILURE": {
           "TITLE": "Fehler beim Aktualisieren",
-          "DESCRIPTION": "Sportleiter hat keine Berechtigung über den Ausgewählten Verein oder die Zielregion."
+          "DESCRIPTION": "Sportleiter hat keine Berechtigung über den ausgewählten Verein oder die Zielregion."
         },
         "NO_LICENSE": {
           "TITLE": "Fehler beim Download",


### PR DESCRIPTION
Wenn man als Sportleiter angemeldet ist und in die Verwaltung wechselt und anschließend versucht einen Verein zu bearbeiten in welcher man nicht die Berechtigung besitzt erscheint eine Fehlermeldung. Im Text der Fehlermeldung ist ein Schreibfehler, das Wort "aktualisieren" muss groß geschrieben werden. 

--> Habe das Dokument überflogen und konnte noch weitere Rechtschreibfehler ausbessern.