### PR TITLE
Erstes Objekt in Wettkampftageliste wird beim Laden autoselected

### DIFF
--- a/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/wettkampftage/wettkampftage.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/wettkampftage/wettkampftage.component.html
@@ -34,6 +34,7 @@
         selectionListHeight="3em"
         [disabled]="wettkampftageForm.dirty"
         [items]="selectedDTOs"
+        [selectedItemIds]="[selectedDTOs[0].id]"
         [optionFieldSelector]="'wettkampfTag'">
       </bla-selectionlist>
 


### PR DESCRIPTION
Sollte noch mit Kampfrichtern getestet werden aber die bekomm ich grad nicht hin lol.
Ticketlink: https://bettercallpaul.atlassian.net/browse/BSAPP-964