### PR TITLE
Übergeordnete Liga wird nicht mehr bei der Bundesliga angezeigt

### DIFF
--- a/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.html
+++ b/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.html
@@ -93,7 +93,9 @@
           </div>
         </bla-row-layout>
 
-        <bla-row-layout>
+
+        <!--- Nur wenn ein Name existiert wird es gerendert --->
+        <bla-row-layout *ngIf="currentRegionDO.regionUebergeordnetAsName">
           <!-- UEBERGEORDNETE REGION -->
           <div class="form-group row">
             <label for="regionUebergeordnet"


### PR DESCRIPTION
Wenn das Object currentRegionDO.regionUebergeordnetAsName einen wert hat wird nur das Feld zur Übergeordneten Liga angezeigt.