### PR TITLE
Tabelle Namen Ueberschriften hinzugefuegt (Benutzer-Uebersicht)

### DIFF
--- a/bogenliga/src/app/modules/verwaltung/components/user/user-overview/user-overview-active.config.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/user/user-overview/user-overview-active.config.ts
@@ -1,13 +1,23 @@
-import {OverviewDialogConfig} from '../../../../shared/components/dialogs';
-import {TableActionType} from '../../../../shared/components/tables/types/table-action-type.enum';
+import {OverviewDialogConfig} from '@shared/components';
+import {TableActionType} from '@shared/components/tables/types/table-action-type.enum';
 import {UserPermission} from '@shared/services';
 
 export const USER_OVERVIEW_CONFIG_ACTIVE: OverviewDialogConfig = {
-  moduleTranslationKey:    'MANAGEMENT',
-  pageTitleTranslationKey: 'MANAGEMENT.USER.TITLE',
+  moduleTranslationKey:    'MANAGEMENT', //Macht Home/Verwaltung/Benutzer-Uebersicht (ganz oben)
+  pageTitleTranslationKey: 'MANAGEMENT.USER.TITLE', //Macht Benutzer - Uebersicht
 
   tableConfig: {
     columns: [
+      {
+        translationKey: 'MANAGEMENT.DSBMITGLIEDER.TABLE.HEADERS.VORNAME',
+        propertyName:   'vorname',
+        width:          20,
+      },
+      {
+        translationKey: 'MANAGEMENT.DSBMITGLIEDER.TABLE.HEADERS.NACHNAME',
+        propertyName:   'nachname',
+        width:          20,
+      },
       {
         translationKey: 'MANAGEMENT.USER.TABLE.HEADERS.EMAIL',
         propertyName:   'email',

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/schuetzen/schuetzen.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/schuetzen/schuetzen.component.ts
@@ -88,7 +88,9 @@ export class SchuetzenComponent extends CommonComponentDirective implements OnIn
     this.loading = true;
 
     this.loadMannschaftById(Number.parseInt(this.route.snapshot.url[2].path, 10));
+
     this.loadVereinById(Number.parseInt(this.route.snapshot.url[1].path, 10));
+
     this.loadVereine();
 
     this.notificationService.discardNotification();
@@ -406,7 +408,8 @@ export class SchuetzenComponent extends CommonComponentDirective implements OnIn
     this.members.forEach((member) => {
       if (member.vereinsId === null) {
         member.vereinsName = 'kein Verein';
-      } else {
+      }
+      else {
         const tmp = this.vereine.find((verein) => {
           return verein.id === member.vereinsId;
         });
@@ -432,7 +435,7 @@ export class SchuetzenComponent extends CommonComponentDirective implements OnIn
 
   private handleVereinSuccess(response: BogenligaResponse<VereinDTO>) {
     this.currentVerein = response.payload;
-    this.loading = false;
+      this.loading = false;
   }
 
   private handleVereinFailure(response: BogenligaResponse<VereinDTO>) {


### PR DESCRIPTION
Bei Benutzer Übersicht wurden zwei Spalten eingefügt mit Vorname und Nachname (unbefüllt -> gefüllt wird in  Sprint 1)