### PR TITLE
fixed missing permission in in verein-details.guard.ts so Ligaleiter can access verein-details

### DIFF
--- a/bogenliga/src/app/modules/verwaltung/guards/verein-detail.guard.ts
+++ b/bogenliga/src/app/modules/verwaltung/guards/verein-detail.guard.ts
@@ -10,6 +10,6 @@ export class VereinDetailGuard implements CanActivate {
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
     // CAN_MODIFY_MY_VEREIN or CAN_MODIFY_STAMMDATEN or CAN_CREATE_MANNSCHAFT required to activate Verein Detail
     return this.currentUserService.hasAnyPermisson(
-      [UserPermission.CAN_MODIFY_MY_VEREIN, UserPermission.CAN_MODIFY_STAMMDATEN]);
+      [UserPermission.CAN_MODIFY_MY_VEREIN, UserPermission.CAN_MODIFY_STAMMDATEN, UserPermission.CAN_CREATE_MANNSCHAFT]);
   }
 }


### PR DESCRIPTION
added CAN_CREATE_MANNSCHAFT to permission list.
Ticket:
https://bettercallpaul.atlassian.net/browse/BSAPP-917
