### PR TITLE
New Pop-Up Message for deleting the Auffuellmannschaft Verein.

### DIFF
--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.ts
@@ -261,30 +261,53 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
 
     const id = this.currentVerein.id;
 
-    const notification: Notification = {
-      id:               NOTIFICATION_DELETE_VEREIN + id,
-      title:            'MANAGEMENT.VEREIN_DETAIL.NOTIFICATION.DELETE.TITLE',
-      description:      'MANAGEMENT.VEREIN_DETAIL.NOTIFICATION.DELETE.DESCRIPTION',
-      descriptionParam: '' + id,
-      severity:         NotificationSeverity.QUESTION,
-      origin:           NotificationOrigin.USER,
-      type:             NotificationType.YES_NO,
-      userAction:       NotificationUserAction.PENDING
-    };
 
-    this.notificationService.observeNotification(NOTIFICATION_DELETE_VEREIN + id)
-        .subscribe((myNotification) => {
+    if(id==9999) {
+      const notification: Notification = {
+        id:               NOTIFICATION_DELETE_VEREIN + id,
+        title:            'MANAGEMENT.VEREIN_DETAIL.NOTIFICATION_AUFFUELLMANNSCHAFT.DELETE.TITLE',
+        description:      'MANAGEMENT.VEREIN_DETAIL.NOTIFICATION_AUFFUELLMANNSCHAFT.DELETE.DESCRIPTION',
+        descriptionParam: '' + id,
+        severity:         NotificationSeverity.QUESTION,
+        origin:           NotificationOrigin.USER,
+        type:             NotificationType.YES_NO,
+        userAction:       NotificationUserAction.PENDING
+      };
+      this.notificationService.observeNotification(NOTIFICATION_DELETE_VEREIN + id)
+          .subscribe((myNotification) => {
+            if (myNotification.userAction === NotificationUserAction.DECLINED) {
+              this.deleteLoading = false;
+            }
+          });
 
-          if (myNotification.userAction === NotificationUserAction.ACCEPTED) {
-            this.vereinProvider.deleteById(id)
-                .then((response) => this.handleDeleteSuccess(response))
-                .catch((response) => this.handleDeleteFailure(response));
-          } else if (myNotification.userAction === NotificationUserAction.DECLINED) {
-            this.deleteLoading = false;
-          }
-        });
+      this.notificationService.showNotification(notification)
 
-    this.notificationService.showNotification(notification);
+    } else {
+      const notification: Notification = {
+        id:               NOTIFICATION_DELETE_VEREIN + id,
+        title:            'MANAGEMENT.VEREIN_DETAIL.NOTIFICATION.DELETE.TITLE',
+        description:      'MANAGEMENT.VEREIN_DETAIL.NOTIFICATION.DELETE.DESCRIPTION',
+        descriptionParam: '' + id,
+        severity:         NotificationSeverity.QUESTION,
+        origin:           NotificationOrigin.USER,
+        type:             NotificationType.YES_NO,
+        userAction:       NotificationUserAction.PENDING
+      };
+
+      this.notificationService.observeNotification(NOTIFICATION_DELETE_VEREIN + id)
+          .subscribe((myNotification) => {
+
+            if (myNotification.userAction === NotificationUserAction.ACCEPTED) {
+              this.vereinProvider.deleteById(id)
+                  .then((response) => this.handleDeleteSuccess(response))
+                  .catch((response) => this.handleDeleteFailure(response));
+            } else if (myNotification.userAction === NotificationUserAction.DECLINED) {
+              this.deleteLoading = false;
+            }
+          });
+
+      this.notificationService.showNotification(notification);
+    }
   }
 
   public onDeleteMannschaft(versionedDataObject: VersionedDataObject): void {

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-overview/verein-overview.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-overview/verein-overview.component.ts
@@ -77,30 +77,51 @@ export class VereinOverviewComponent extends CommonComponentDirective implements
 
     this.rows = showDeleteLoadingIndicatorIcon(this.rows, id);
 
-    const notification: Notification = {
-      id:               NOTIFICATION_DELETE_VEREINE + id,
-      title:            'MANAGEMENT.VEREINE.NOTIFICATION.DELETE.TITLE',
-      description:      'MANAGEMENT.VEREINE.NOTIFICATION.DELETE.DESCRIPTION',
-      descriptionParam: '' + id,
-      severity:         NotificationSeverity.QUESTION,
-      origin:           NotificationOrigin.USER,
-      type:             NotificationType.YES_NO,
-      userAction:       NotificationUserAction.PENDING
-    };
+    if(id == 9999) {
+      const notification: Notification = {
+        id:               NOTIFICATION_DELETE_VEREINE + id,
+        title:            'MANAGEMENT.VEREINE.NOTIFICATION_AUFFUELLMANNSCHAFT.DELETE.TITLE',
+        description:      'MANAGEMENT.VEREINE.NOTIFICATION_AUFFUELLMANNSCHAFT.DELETE.DESCRIPTION',
+        descriptionParam: '' + id,
+        severity:         NotificationSeverity.QUESTION,
+        origin:           NotificationOrigin.USER,
+        type:             NotificationType.YES_NO,
+        userAction:       NotificationUserAction.PENDING
+      };
+      this.notificationService.observeNotification(NOTIFICATION_DELETE_VEREINE + id)
+          .subscribe((myNotification) => {
+            if (myNotification.userAction === NotificationUserAction.DECLINED) {
+              this.rows = hideLoadingIndicator(this.rows, id);
+            }
+          });
+      this.notificationService.showNotification(notification);
 
-    this.notificationService.observeNotification(NOTIFICATION_DELETE_VEREINE + id)
-        .subscribe((myNotification) => {
-          if (myNotification.userAction === NotificationUserAction.ACCEPTED) {
-            this.vereinDataProvider.deleteById(id)
-                .then((response) => this.loadTableRows())
-                .catch((response) => this.rows = hideLoadingIndicator(this.rows, id));
-          } else if (myNotification.userAction === NotificationUserAction.DECLINED) {
-            this.rows = hideLoadingIndicator(this.rows, id);
-          }
-        });
+    }
+    else {
+      const notification: Notification = {
+        id:               NOTIFICATION_DELETE_VEREINE + id,
+        title:            'MANAGEMENT.VEREINE.NOTIFICATION.DELETE.TITLE',
+        description:      'MANAGEMENT.VEREINE.NOTIFICATION.DELETE.DESCRIPTION',
+        descriptionParam: '' + id,
+        severity:         NotificationSeverity.QUESTION,
+        origin:           NotificationOrigin.USER,
+        type:             NotificationType.YES_NO,
+        userAction:       NotificationUserAction.PENDING
+      };
 
-    this.notificationService.showNotification(notification);
+      this.notificationService.observeNotification(NOTIFICATION_DELETE_VEREINE + id)
+          .subscribe((myNotification) => {
+            if (myNotification.userAction === NotificationUserAction.ACCEPTED) {
+              this.vereinDataProvider.deleteById(id)
+                  .then((response) => this.loadTableRows())
+                  .catch((response) => this.rows = hideLoadingIndicator(this.rows, id));
+            } else if (myNotification.userAction === NotificationUserAction.DECLINED) {
+              this.rows = hideLoadingIndicator(this.rows, id);
+            }
+          });
 
+      this.notificationService.showNotification(notification);
+    }
   }
 
   private loadTableRows() {

--- a/bogenliga/src/assets/i18n/de.json
+++ b/bogenliga/src/assets/i18n/de.json
@@ -837,6 +837,12 @@
           "TITLE": "Verein löschen",
           "DESCRIPTION": "Wollen Sie den Verein wirklich löschen? Der Verein ist danach nicht mehr verfügbar."
         }
+      },
+      "NOTIFICATION_AUFFUELLMANNSCHAFT": {
+        "DELETE": {
+          "TITLE": "Verein Auffüllmannschaft löschen",
+          "DESCRIPTION": "Wollen Sie den Verein wirklich löschen? ACHTUNG! Es können keine Auffüllmannschaften mehr erstellt werden!"
+        }
       }
     },
     "VEREIN_DETAIL": {
@@ -912,6 +918,12 @@
         "NO_LICENSE": {
           "TITLE": "Fehler beim Download",
           "DESCRIPTION": "Der Lizenzenübersicht konnte nicht heruntergeladen werden, da eine oder mehreren Lizenzen nicht vorhanden sind."
+        }
+      },
+      "NOTIFICATION_AUFFUELLMANNSCHAFT": {
+        "DELETE": {
+          "TITLE": "Verein Auffüllmannschaft löschen",
+          "DESCRIPTION": "Wollen Sie den Verein wirklich löschen? ACHTUNG! Es können keine Auffüllmannschaften mehr erstellt werden!"
         }
       }
     },

--- a/bogenliga/src/assets/i18n/en.json
+++ b/bogenliga/src/assets/i18n/en.json
@@ -797,6 +797,12 @@
           "TITLE": "Delete club",
           "DESCRIPTION": "Are you sure, you want to delete the club with ID=%s? This can not be undone."
         }
+      },
+      "NOTIFICATION_AUFFUELLMANNSCHAFT": {
+        "DELETE": {
+          "TITLE": "Delete fill in club",
+          "DESCRIPTION": "Are you sure, want to delete this club? This can not be undone. ATTENTION! It will no longer be possible to create a fill in team!"
+        }
       }
     },
     "VEREIN_DETAIL": {
@@ -809,7 +815,7 @@
         },
         "VEREIN_IDENTIFIER": {
           "LABEL": "Club number",
-          "PLACEHOLDER": "Please enter a identifier for the club",
+          "PLACEHOLDER": "Please enter an identifier for the club",
           "ERROR": "Please enter a valid identifier."
         },
         "VEREIN_REGION": {
@@ -868,6 +874,12 @@
         "SAVE_FAILURE": {
           "TITLE": "Error while saving",
           "DESCRIPTION": "Sports director has no authority over this club or this target region."
+        }
+      },
+      "NOTIFICATION_AUFFUELLMANNSCHAFT": {
+        "DELETE": {
+          "TITLE": "Delete fill in club",
+          "DESCRIPTION": "Are you sure, want to delete this club? This can not be undone. ATTENTION! It will no longer be possible to create a fill in team!"
         }
       }
     },


### PR DESCRIPTION
A Pop-Up message has been created that is displayed when you try to delete the Verein that is used to create the Auffuellmannschaft. At the moment you can still delete this club, but a different Pop-up message will be displayed than for the other deletion attempts for the other Vereine.