### PR TITLE
Changed download button to link that shows the file name.

### DIFF
--- a/bogenliga/package-lock.json
+++ b/bogenliga/package-lock.json
@@ -50,7 +50,7 @@
         "@types/jasminewd2": "2.0.3",
         "@types/node": "^12.11.1",
         "codelyzer": "^6.0.0",
-        "cypress": "12.1.0",
+        "cypress": "^12.1.0",
         "events": "3.0.0",
         "jasmine-core": "~3.5.0",
         "jasmine-spec-reporter": "~5.0.0",

--- a/bogenliga/package.json
+++ b/bogenliga/package.json
@@ -59,7 +59,7 @@
     "@types/jasminewd2": "2.0.3",
     "@types/node": "^12.11.1",
     "codelyzer": "^6.0.0",
-    "cypress": "12.1.0",
+    "cypress": "^12.1.0",
     "events": "3.0.0",
     "jasmine-core": "~3.5.0",
     "jasmine-spec-reporter": "~5.0.0",

--- a/bogenliga/src/app/modules/home/components/home/home.component.html
+++ b/bogenliga/src/app/modules/home/components/home/home.component.html
@@ -57,10 +57,11 @@
           </div>
         </div>
 
-        <!-- File Download Button -->
-        <button (click)="fileDownload()">DownloadFile</button>
+        <!-- File Download Link -->
+        <!-- Bug? File selectedLigaDetailFileName ist null, Name des files kann nicht angezeigt werden -->
+         <a (click)="fileDownload()">Download {{this.selectedLigaDetailFileName + this.getFileType(this.selectedLigaDetailFileType)}}</a>
 
-        <!-- Button -->
+         <!-- Button -->
         <div id="Button">
           <bla-actionbutton
             [id]="'ligadetailRegionSaveButton'"

--- a/bogenliga/src/app/modules/home/components/home/home.component.ts
+++ b/bogenliga/src/app/modules/home/components/home/home.component.ts
@@ -233,7 +233,8 @@ export class HomeComponent extends CommonComponentDirective implements OnInit, O
 
   /**File Download, converts Base64 string back to its original file with its original name*/
   public fileDownload(){
-
+    console.log("this.selectedLigaDetailFileName: "+ this.selectedLigaDetailFileName);
+    //typeOfFile wirft Fehler, weil die variablen NULL sind. Siehe oberer console.log)
     const typeOfFile = this.selectedLigaDetailBase64.substring(this.selectedLigaDetailBase64.indexOf(':')+1, this.selectedLigaDetailBase64.indexOf(';'))
     this.selectedLigaDetailBase64 = this.selectedLigaDetailBase64.replace('data:' + typeOfFile + ';base64,', '');
 


### PR DESCRIPTION
Die Variablen mit den file names / types sind null, wenn man in die Detailansicht navigiert. Daher kann der Dateiname im Link (im moment) nicht angezeigt werden.