### PR TITLE
Fixed issue 1556 - Incorrect Button Icons

### DIFF
--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.html
@@ -186,7 +186,7 @@
                             [id]="'vereinSaveButton'"
                             [loading]="saveLoading"
                             [color]="ActionButtonColors.SUCCESS"
-                            [iconClass]="'save'"
+                            [iconClass]="'plus'"
                             data-cy="vereine-add-button">
             {{ 'MANAGEMENT.VEREIN_DETAIL.FORM.SAVE' | translate }}
           </bla-actionbutton>
@@ -196,7 +196,7 @@
                             [id]="'vereinUpdateButton'"
                             [loading]="saveLoading"
                             [color]="ActionButtonColors.SUCCESS"
-                            [iconClass]="'plus'"
+                            [iconClass]="'save'"
                             data-cy="vereine-update-button">
             {{ 'MANAGEMENT.VEREIN_DETAIL.FORM.UPDATE' | translate }}
           </bla-actionbutton>


### PR DESCRIPTION
Initially, the wrong icon was edited due to a mixup. This fixes this. Changes icon from plus to save and reverts the previous merge's change.