### PR TITLE
#1591 löschen vom protokoll der datenmigration epic api entpunkt

### DIFF
--- a/bogenliga/cypress/e2e/bsapp/bsapp-e2e-migration.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/bsapp-e2e-migration.cy.js
@@ -139,16 +139,6 @@ describe('Verwaltung/Migration tests', function () {
     cy.wait(1000)
     cy.wait('@filter')
   })
-  it('Filtern nach Zeitstempel Letzter Monat', () => {
-    cy.viewport(1920,1080)
-    cy.intercept({
-      method: 'GET',
-      url: `http://localhost:9000/v1/trigger/findErrors?offsetMultiplicator=0&queryPageLimit=500&dateInterval=1%20MONTH`,
-    }).as('filter');
-    cy.get('[data-cy=timestamp-filter-selection]').select('0: letzter Monat')
-    cy.wait(1000)
-    cy.wait('@filter')
-  })
   it('Filtern nach Zeitstempel letzten drei Monate', () => {
     cy.viewport(1920,1080)
     cy.intercept({
@@ -156,6 +146,16 @@ describe('Verwaltung/Migration tests', function () {
       url: `http://localhost:9000/v1/trigger/findErrors?offsetMultiplicator=0&queryPageLimit=500&dateInterval=3%20MONTH`,
     }).as('filter');
     cy.get('[data-cy=timestamp-filter-selection]').select('1: letzten drei Monate')
+    cy.wait(1000)
+    cy.wait('@filter')
+  })
+  it('Filtern nach Zeitstempel letzter Monat', () => {
+    cy.viewport(1920,1080)
+    cy.intercept({
+      method: 'GET',
+      url: `http://localhost:9000/v1/trigger/findErrors?offsetMultiplicator=0&queryPageLimit=500&dateInterval=1%20MONTH`,
+    }).as('filter');
+    cy.get('[data-cy=timestamp-filter-selection]').select('0: letzter Monat')
     cy.wait(1000)
     cy.wait('@filter')
   })

--- a/bogenliga/cypress/e2e/bsapp/bsapp-e2e-migration.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/bsapp-e2e-migration.cy.js
@@ -15,7 +15,7 @@ describe('Verwaltung/Migration tests', function () {
    */
   it('Anzeige Verwaltung', () => {
     cy.loginAdmin()
-    cy.wait(30000)
+    cy.wait(60000)
     cy.url().should('include', '#/home')
     cy.get('[data-cy=sidebar-verwaltung-button]').click()
     cy.wait(1000)
@@ -41,9 +41,10 @@ describe('Verwaltung/Migration tests', function () {
    * 4. if a call was made to Backend
    */
   it('Anzeige Migration Section and FindAll Call', () => {
+    cy.viewport(1920,1080)
     cy.intercept({
       method: 'GET',
-      url: `http://localhost:9000/v1/trigger/findErrors?offsetMultiplicator=0&queryPageLimit=500`,
+      url: `http://localhost:9000/v1/trigger/findErrors?offsetMultiplicator=0&queryPageLimit=500&dateInterval=1%20MONTH`,
     }).as('findallErrors-request');
     cy.get('[data-cy=sidebar-verwaltung-button]').click()
     cy.wait(1000)
@@ -57,75 +58,134 @@ describe('Verwaltung/Migration tests', function () {
   })
 
   it('Filtern nach erfolgreichen Einträgen', () => {
+    cy.viewport(1920,1080)
     cy.intercept({
       method: 'GET',
-      url: `http://localhost:9000/v1/trigger/findSuccessed?offsetMultiplicator=0&queryPageLimit=500`,
+      url: `http://localhost:9000/v1/trigger/findSuccessed?offsetMultiplicator=0&queryPageLimit=500&dateInterval=1%20MONTH`,
     }).as('filter');
     cy.get('[data-cy=status-filter-selection]').select('1: Erfolgreich')
     cy.wait(2000)
     cy.wait('@filter')
   })
   it('Filtern nach laufenden Einträgen', () => {
+    cy.viewport(1920,1080)
     cy.intercept({
       method: 'GET',
-      url: `http://localhost:9000/v1/trigger/findInProgress?offsetMultiplicator=0&queryPageLimit=500`,
+      url: `http://localhost:9000/v1/trigger/findInProgress?offsetMultiplicator=0&queryPageLimit=500&dateInterval=1%20MONTH`,
     }).as('filter');
     cy.get('[data-cy=status-filter-selection]').select('2: Laufend')
     cy.wait(1000)
     cy.wait('@filter')
   })
   it('Filtern nach neuen Einträgen', () => {
+    cy.viewport(1920,1080)
     cy.intercept({
       method: 'GET',
-      url: `http://localhost:9000/v1/trigger/findNews?offsetMultiplicator=0&queryPageLimit=500`,
+      url: `http://localhost:9000/v1/trigger/findNews?offsetMultiplicator=0&queryPageLimit=500&dateInterval=1%20MONTH`,
     }).as('filter');
     cy.get('[data-cy=status-filter-selection]').select('3: Neu')
     cy.wait(1000)
     cy.wait('@filter')
   })
   it('Filtern nach allen Einträgen', () => {
+    cy.viewport(1920,1080)
     cy.intercept({
       method: 'GET',
-      url: `http://localhost:9000/v1/trigger/findAllWithPages?offsetMultiplicator=0&queryPageLimit=500`,
+      url: `http://localhost:9000/v1/trigger/findAllWithPages?offsetMultiplicator=0&queryPageLimit=500&dateInterval=1%20MONTH`,
     }).as('filter');
     cy.get('[data-cy=status-filter-selection]').select('4: Alle')
     cy.wait(1000)
     cy.wait('@filter')
   })
   it('Previous Page Test', () => {
+    cy.viewport(1920,1080)
     cy.intercept({
       method: 'GET',
-      url: `http://localhost:9000/v1/trigger/findAllWithPages?offsetMultiplicator=1&queryPageLimit=500`,
+      url: `http://localhost:9000/v1/trigger/findAllWithPages?offsetMultiplicator=0&queryPageLimit=500&dateInterval=1%20MONTH`,
     }).as('nextPage');
     cy.get('[data-cy=next-page-button]').click()
   })
   it('Next Page Test', () => {
+    cy.viewport(1920,1080)
     cy.intercept({
       method: 'GET',
-      url: `http://localhost:9000/v1/trigger/findAllWithPages?offsetMultiplicator=0&queryPageLimit=500`,
+      url: `http://localhost:9000/v1/trigger/findAllWithPages?offsetMultiplicator=0&queryPageLimit=500&dateInterval=1%20MONTH`,
     }).as('previousPage');
     cy.get('[data-cy=previous-page-button]').click()
   })
   it('Next Page Test Above', () => {
+    cy.viewport(1920,1080)
     cy.intercept({
       method: 'GET',
-      url: `http://localhost:9000/v1/trigger/findAllWithPages?offsetMultiplicator=1&queryPageLimit=500`,
+      url: `http://localhost:9000/v1/trigger/findAllWithPages?offsetMultiplicator=0&queryPageLimit=500&dateInterval=1%20MONTH`,
     }).as('nextPage');
     cy.get('[data-cy=next-page-button-above]').click()
   })
   it('Previous Page Test Above', () => {
+    cy.viewport(1920,1080)
     cy.intercept({
       method: 'GET',
-      url: `http://localhost:9000/v1/trigger/findAllWithPages?offsetMultiplicator=0&queryPageLimit=500`,
+      url: `http://localhost:9000/v1/trigger/findAllWithPages?offsetMultiplicator=0&queryPageLimit=500&dateInterval=1%20MONTH`,
     }).as('previousPage');
     cy.get('[data-cy=previous-page-button-above]').click()
   })
   it('Filtern nach error Einträgen', () => {
+    cy.viewport(1920,1080)
     cy.intercept({
       method: 'GET',
-      url: `http://localhost:9000/v1/trigger/findErrors?offsetMultiplicator=0&queryPageLimit=500`,
+      url: `http://localhost:9000/v1/trigger/findErrors?offsetMultiplicator=0&queryPageLimit=500&dateInterval=1%20MONTH`,
     }).as('filter');
     cy.get('[data-cy=status-filter-selection]').select('0: Fehlgeschlagen')
+    cy.wait(1000)
+    cy.wait('@filter')
+  })
+  it('Filtern nach Zeitstempel Letzter Monat', () => {
+    cy.viewport(1920,1080)
+    cy.intercept({
+      method: 'GET',
+      url: `http://localhost:9000/v1/trigger/findErrors?offsetMultiplicator=0&queryPageLimit=500&dateInterval=1%20MONTH`,
+    }).as('filter');
+    cy.get('[data-cy=timestamp-filter-selection]').select('0: letzter Monat')
+    cy.wait(1000)
+    cy.wait('@filter')
+  })
+  it('Filtern nach Zeitstempel letzten drei Monate', () => {
+    cy.viewport(1920,1080)
+    cy.intercept({
+      method: 'GET',
+      url: `http://localhost:9000/v1/trigger/findErrors?offsetMultiplicator=0&queryPageLimit=500&dateInterval=3%20MONTH`,
+    }).as('filter');
+    cy.get('[data-cy=timestamp-filter-selection]').select('1: letzten drei Monate')
+    cy.wait(1000)
+    cy.wait('@filter')
+  })
+  it('Filtern nach Zeitstempel letzten sechs Monate', () => {
+    cy.viewport(1920,1080)
+    cy.intercept({
+      method: 'GET',
+      url: `http://localhost:9000/v1/trigger/findErrors?offsetMultiplicator=0&queryPageLimit=500&dateInterval=6%20MONTH`,
+    }).as('filter');
+    cy.get('[data-cy=timestamp-filter-selection]').select('2: letzten sechs Monate')
+    cy.wait(1000)
+    cy.wait('@filter')
+  })
+  it('Filtern nach Zeitstempel im letzten Jahr', () => {
+    cy.viewport(1920,1080)
+    cy.intercept({
+      method: 'GET',
+      url: `http://localhost:9000/v1/trigger/findErrors?offsetMultiplicator=0&queryPageLimit=500&dateInterval=12%20MONTH`,
+    }).as('filter');
+    cy.get('[data-cy=timestamp-filter-selection]').select('3: im letzten Jahr')
+    cy.wait(1000)
+    cy.wait('@filter')
+  })
+  it('Filtern nach Zeitstempel alle', () => {
+    cy.viewport(1920,1080)
+    cy.intercept({
+      method: 'GET',
+      url: `http://localhost:9000/v1/trigger/findErrors?offsetMultiplicator=0&queryPageLimit=500&dateInterval=20%20YEAR`,
+    }).as('filter');
+    cy.get('[data-cy=timestamp-filter-selection]').select('4: alle')
     cy.wait(1000)
     cy.wait('@filter')
   })

--- a/bogenliga/src/app/modules/shared/components/dialogs/overview-dialog/overview-dialog.component.html
+++ b/bogenliga/src/app/modules/shared/components/dialogs/overview-dialog/overview-dialog.component.html
@@ -14,21 +14,24 @@
 
     <div class="overview-dialog-add"
          >
-      <bla-filterinputbar
-        *ngIf="isCustomActionButton"
-        [item]="timeItem"
-        [items]="timeItems"
-        (onFilterButtonClicked) ="onTimestampClick()" >
-      </bla-filterinputbar>
-      <bla-actionbutton
-        data-cy="delete-button"
-        *ngIf="isCustomActionButton"
-        [color]="ActionButtonColors.SUCCESS"
-        [iconClass]="'minus'"
-        (onClick)="onDeleteButtonClick()"
-      >
-        {{"Löschen der Einträge"}}
-      </bla-actionbutton>
+      <div class="deleteButtonAndTimestampFilter">
+        <bla-filterinputbar class="item"
+          [filterlabel]="timestampDropdownLabel"
+          *ngIf="isCustomActionButton"
+          [item]="timeItem"
+          [items]="timeItems"
+          (onFilterButtonClicked) ="onTimestampClick()" >
+        </bla-filterinputbar>
+        <bla-actionbutton class="item"
+          data-cy="delete-button"
+          *ngIf="isCustomActionButton"
+          [color]="ActionButtonColors.DANGER"
+          [iconClass]="'minus'"
+          (onClick)="onDeleteButtonClick()"
+        >
+          {{"Löschen der Einträge"}}
+        </bla-actionbutton>
+      </div>
       <div class="changePageButtonsAbove"  >
         <bla-actionbutton
           *ngIf="changePageButtons"
@@ -47,22 +50,25 @@
           {{"nächste Seite"}}
         </bla-actionbutton>
       </div>
-      <bla-filterinputbar
-                          *ngIf="isCustomActionButton"
-                          [item]="filterItem"
-                          [items]="filterItems"
-                          (onFilterButtonClicked) ="onFilterClick()" >
-      </bla-filterinputbar>
-      <bla-actionbutton
-        data-cy="start-migration-button"
-        *ngIf="isCustomActionButton"
-        [color]="ActionButtonColors.SUCCESS"
-        [iconClass]="'plus'"
-        (onClick)="onCustomActionButtonClick()"
-      >
-        {{buttonLabel || "Neu"}}
-      </bla-actionbutton>
-
+      <div class="deleteButtonAndTimestampFilter">
+        <bla-filterinputbar class="item"
+          [filterlabel]="filterDropdownLabel"
+                            *ngIf="isCustomActionButton"
+                            [item]="filterItem"
+                            [items]="filterItems"
+                            (onFilterButtonClicked) ="onFilterClick()" >
+        </bla-filterinputbar>
+        <bla-actionbutton
+          class="item"
+          data-cy="start-migration-button"
+          *ngIf="isCustomActionButton"
+          [color]="ActionButtonColors.SUCCESS"
+          [iconClass]="'plus'"
+          (onClick)="onCustomActionButtonClick()"
+        >
+          {{buttonLabel || "Neu"}}
+        </bla-actionbutton>
+      </div>
       <bla-actionbutton
         routerLink="add"
         *ngIf="!isCustomActionButton"

--- a/bogenliga/src/app/modules/shared/components/dialogs/overview-dialog/overview-dialog.component.html
+++ b/bogenliga/src/app/modules/shared/components/dialogs/overview-dialog/overview-dialog.component.html
@@ -15,13 +15,13 @@
     <div class="overview-dialog-add"
          >
       <div class="deleteButtonAndTimestampFilter">
-        <bla-filterinputbar class="item"
+        <bla-filterTimestampInputbar class="item"
           [filterlabel]="timestampDropdownLabel"
           *ngIf="isCustomActionButton"
           [item]="timeItem"
           [items]="timeItems"
           (onFilterButtonClicked) ="onTimestampClick()" >
-        </bla-filterinputbar>
+        </bla-filterTimestampInputbar>
         <bla-actionbutton class="item"
           data-cy="delete-button"
           *ngIf="isCustomActionButton"
@@ -54,6 +54,7 @@
         <bla-filterinputbar class="item"
           [filterlabel]="filterDropdownLabel"
                             *ngIf="isCustomActionButton"
+                            [id]="cypressTagStatus"
                             [item]="filterItem"
                             [items]="filterItems"
                             (onFilterButtonClicked) ="onFilterClick()" >

--- a/bogenliga/src/app/modules/shared/components/dialogs/overview-dialog/overview-dialog.component.html
+++ b/bogenliga/src/app/modules/shared/components/dialogs/overview-dialog/overview-dialog.component.html
@@ -29,7 +29,7 @@
           [iconClass]="'minus'"
           (onClick)="onDeleteButtonClick()"
         >
-          {{"Löschen der Einträge"}}
+          {{"Gefilterte Einträge löschen"}}
         </bla-actionbutton>
       </div>
       <div class="changePageButtonsAbove"  >

--- a/bogenliga/src/app/modules/shared/components/dialogs/overview-dialog/overview-dialog.component.html
+++ b/bogenliga/src/app/modules/shared/components/dialogs/overview-dialog/overview-dialog.component.html
@@ -14,6 +14,21 @@
 
     <div class="overview-dialog-add"
          >
+      <bla-filterinputbar
+        *ngIf="isCustomActionButton"
+        [item]="timeItem"
+        [items]="timeItems"
+        (onFilterButtonClicked) ="onTimestampClick()" >
+      </bla-filterinputbar>
+      <bla-actionbutton
+        data-cy="delete-button"
+        *ngIf="isCustomActionButton"
+        [color]="ActionButtonColors.SUCCESS"
+        [iconClass]="'minus'"
+        (onClick)="onDeleteButtonClick()"
+      >
+        {{"Löschen der Einträge"}}
+      </bla-actionbutton>
       <div class="changePageButtonsAbove"  >
         <bla-actionbutton
           *ngIf="changePageButtons"
@@ -38,7 +53,6 @@
                           [items]="filterItems"
                           (onFilterButtonClicked) ="onFilterClick()" >
       </bla-filterinputbar>
-
       <bla-actionbutton
         data-cy="start-migration-button"
         *ngIf="isCustomActionButton"

--- a/bogenliga/src/app/modules/shared/components/dialogs/overview-dialog/overview-dialog.component.scss
+++ b/bogenliga/src/app/modules/shared/components/dialogs/overview-dialog/overview-dialog.component.scss
@@ -7,8 +7,11 @@
 
   .overview-dialog-add {
     display: flex;
-    justify-content: space-between; /* Damit die Buttons an den Enden der Reihe sind */
+    justify-content: space-between; /* Damit die Divs an den Enden der Reihe sind */
     align-items: center;
+  }
+  .overview-dialog-add div {
+    flex-grow: 1; /* Streckt die Divs automatisch aus, um den verfügbaren Platz auszufüllen */
   }
 }
 
@@ -17,7 +20,7 @@
   display: flex;
   justify-content: center; /* Zentriert die Elemente horizontal */
   align-items: center;
-  margin-left: 20rem;
+
 }
 
 .changePageButtons {
@@ -25,5 +28,11 @@
   justify-content: center;
   align-items: center;
 }
-
-
+.deleteButtonAndTimestampFilter{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.item {
+  margin: 10px;
+}

--- a/bogenliga/src/app/modules/shared/components/dialogs/overview-dialog/overview-dialog.component.ts
+++ b/bogenliga/src/app/modules/shared/components/dialogs/overview-dialog/overview-dialog.component.ts
@@ -29,6 +29,8 @@ export class OverviewDialogComponent extends CommonSecuredDirective implements O
   @Input() public timeItems: Array<string>;
   @Input() public timestampDropdownLabel: string;
   @Input() public filterDropdownLabel: string;
+  @Input() public cypressTagTimestamp: string;
+  @Input() public cypressTagStatus: string;
 
 
   public ActionButtonColors = ActionButtonColors;

--- a/bogenliga/src/app/modules/shared/components/dialogs/overview-dialog/overview-dialog.component.ts
+++ b/bogenliga/src/app/modules/shared/components/dialogs/overview-dialog/overview-dialog.component.ts
@@ -25,6 +25,8 @@ export class OverviewDialogComponent extends CommonSecuredDirective implements O
   @Input() public showFilterButton: boolean = false;
   @Input() public filterItem: string;
   @Input() public filterItems: Array<string>;
+  @Input() public timeItem: string;
+  @Input() public timeItems: Array<string>;
 
   public ActionButtonColors = ActionButtonColors;
 
@@ -37,6 +39,9 @@ export class OverviewDialogComponent extends CommonSecuredDirective implements O
   @Output() public onNextPageButtonClicked = new EventEmitter<string>();
   @Output() public onPreviousPageButtonClicked = new EventEmitter<string>();
   @Output() public onFilterClicked = new EventEmitter<string>();
+  @Output() public onDeleteButtonClicked = new EventEmitter<string>();
+  @Output() public onTimestampClicked = new EventEmitter<string>();
+
   constructor(private currentUserService: CurrentUserService) {
     super(currentUserService);
   }
@@ -67,11 +72,17 @@ export class OverviewDialogComponent extends CommonSecuredDirective implements O
   public onCustomActionButtonClick() {
     this.onCustomActionButtonClicked.emit();
   }
+  public onDeleteButtonClick() {
+    this.onDeleteButtonClicked.emit();
+  }
   public onFilterClick() {
     this.onFilterClicked.emit();
   }
   public onPreviousPageButtonClick() {
     this.onPreviousPageButtonClicked.emit();
+  }
+  public onTimestampClick() {
+    this.onTimestampClicked.emit();
   }
   public onNextPageButtonClick() {
     this.onNextPageButtonClicked.emit();

--- a/bogenliga/src/app/modules/shared/components/dialogs/overview-dialog/overview-dialog.component.ts
+++ b/bogenliga/src/app/modules/shared/components/dialogs/overview-dialog/overview-dialog.component.ts
@@ -27,6 +27,9 @@ export class OverviewDialogComponent extends CommonSecuredDirective implements O
   @Input() public filterItems: Array<string>;
   @Input() public timeItem: string;
   @Input() public timeItems: Array<string>;
+  @Input() public timestampDropdownLabel: string;
+  @Input() public filterDropdownLabel: string;
+
 
   public ActionButtonColors = ActionButtonColors;
 

--- a/bogenliga/src/app/modules/shared/components/selectionlists/filterTimestampInputbar/filterTimestampInputbar.component.html
+++ b/bogenliga/src/app/modules/shared/components/selectionlists/filterTimestampInputbar/filterTimestampInputbar.component.html
@@ -1,0 +1,15 @@
+<div class="filterinputbar">
+  <div class="row" id="rowsFilter">
+    <label class="form-label-box col-form-label" id="filterFormLabel">
+      <span>{{ filterlabel | translate }}</span>
+    </label>
+    <div class="col-sm-8">
+      <select class="form-control"
+              data-cy="timestamp-filter-selection"
+              [(ngModel)]="item"
+              (ngModelChange)="onFilterButtonClick()">
+        <option *ngFor="let status of items" [ngValue]="status"> {{status}}</option>
+      </select>
+    </div>
+  </div>
+</div>

--- a/bogenliga/src/app/modules/shared/components/selectionlists/filterTimestampInputbar/filterTimestampInputbar.component.scss
+++ b/bogenliga/src/app/modules/shared/components/selectionlists/filterTimestampInputbar/filterTimestampInputbar.component.scss
@@ -1,0 +1,24 @@
+.filterinputbar {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  width: fit-content;
+}
+.row{
+  display: flex;
+  align-items: center;
+}
+
+.form-label-box{
+  flex: 0 0 auto;
+  padding-right: 15px;
+}
+#filterFormLabel{
+  display: block;
+  line-height: 1.5;
+  height: 100%;
+}
+
+.form-control{
+  width: fit-content;
+}

--- a/bogenliga/src/app/modules/shared/components/selectionlists/filterTimestampInputbar/filterTimestampInputbar.component.ts
+++ b/bogenliga/src/app/modules/shared/components/selectionlists/filterTimestampInputbar/filterTimestampInputbar.component.ts
@@ -4,12 +4,12 @@ import {TranslatePipe} from '@ngx-translate/core';
 import {MigrationComponent} from '@verwaltung/components';
 
 @Component({
-  selector: 'bla-filterinputbar',
-  templateUrl: './filterinputbar.component.html',
-  styleUrls: ['./filterinputbar.component.scss'],
+  selector: 'bla-filterTimestampInputbar',
+  templateUrl: './filterTimestampInputbar.component.html',
+  styleUrls: ['./filterTimestampInputbar.component.scss'],
   providers: [TranslatePipe]
 })
-export class FilterinputbarComponent implements OnInit, OnChanges {
+export class FilterTimestampInputbarComponent implements OnInit, OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
 
   }
@@ -27,12 +27,12 @@ export class FilterinputbarComponent implements OnInit, OnChanges {
 
   }
   public onFilterButtonClick() {
-    FilterinputbarComponent.currentItem = this.item;
-    console.log("Current ITEM is: " + FilterinputbarComponent.currentItem)
-    if(this.timestamps.includes(FilterinputbarComponent.currentItem)){
-      FilterinputbarComponent.currentTimestamp = FilterinputbarComponent.currentItem
+    FilterTimestampInputbarComponent.currentItem = this.item;
+    console.log("Current ITEM is: " + FilterTimestampInputbarComponent.currentItem)
+    if(this.timestamps.includes(FilterTimestampInputbarComponent.currentItem)){
+      FilterTimestampInputbarComponent.currentTimestamp = FilterTimestampInputbarComponent.currentItem
     }else{
-      FilterinputbarComponent.currentStatus = FilterinputbarComponent.currentItem
+      FilterTimestampInputbarComponent.currentStatus = FilterTimestampInputbarComponent.currentItem
     }
     this.onFilterButtonClicked.emit();
   }

--- a/bogenliga/src/app/modules/shared/components/selectionlists/filterinputbar/filterinputbar.component.html
+++ b/bogenliga/src/app/modules/shared/components/selectionlists/filterinputbar/filterinputbar.component.html
@@ -1,7 +1,7 @@
 <div class="filterinputbar">
   <div class="row" id="rowsFilter">
     <label class="form-label-box col-form-label" id="filterFormLabel">
-      <span>{{ 'Filter' | translate }}</span>
+      <span>{{ filterlabel | translate }}</span>
     </label>
     <div class="col-sm-8">
       <select class="form-control"

--- a/bogenliga/src/app/modules/shared/components/selectionlists/filterinputbar/filterinputbar.component.ts
+++ b/bogenliga/src/app/modules/shared/components/selectionlists/filterinputbar/filterinputbar.component.ts
@@ -24,13 +24,15 @@ export class FilterinputbarComponent implements OnInit, OnChanges {
   @Output() public onFilterButtonClicked = new EventEmitter<string>();
   public timestamps = ["letzter Monat", "letzten drei Monate", "letzten sechs Monate", "im letzten Jahr", "Alle"];
   public static currentItem:string;
+  public static currentStatus:string;
   public static currentTimestamp:string;
   public onFilterButtonClick() {
-    if( this.items.includes(FilterinputbarComponent.currentItem)){
-        FilterinputbarComponent.currentTimestamp=FilterinputbarComponent.currentItem
+    FilterinputbarComponent.currentItem = this.item;
+    console.log("Current ITEM is: " + FilterinputbarComponent.currentItem)
+    if(this.timestamps.includes(FilterinputbarComponent.currentItem)){
+      FilterinputbarComponent.currentTimestamp = FilterinputbarComponent.currentItem
     }else{
-      FilterinputbarComponent.currentItem = this.item;
-      this.onFilterButtonClicked.emit();
+      FilterinputbarComponent.currentStatus = FilterinputbarComponent.currentItem
     }
   }
 

--- a/bogenliga/src/app/modules/shared/components/selectionlists/filterinputbar/filterinputbar.component.ts
+++ b/bogenliga/src/app/modules/shared/components/selectionlists/filterinputbar/filterinputbar.component.ts
@@ -22,7 +22,7 @@ export class FilterinputbarComponent implements OnInit, OnChanges {
   @Input() items: Array<string>;
 
   @Output() public onFilterButtonClicked = new EventEmitter<string>();
-  public timestamps = ["letzter Monat", "letzten drei Monate", "letzten sechs Monate", "im letzten Jahr", "Alle"];
+  public timestamps = ["letzter Monat", "letzten drei Monate", "letzten sechs Monate", "im letzten Jahr", "unbegrenzt"];
   public static currentItem:string;
   public static currentStatus:string;
   public static currentTimestamp:string;

--- a/bogenliga/src/app/modules/shared/components/selectionlists/filterinputbar/filterinputbar.component.ts
+++ b/bogenliga/src/app/modules/shared/components/selectionlists/filterinputbar/filterinputbar.component.ts
@@ -16,7 +16,7 @@ export class FilterinputbarComponent implements OnInit, OnChanges {
   ngOnInit(): void {
     throw new Error("Method not implemented.");
   }
-
+  @Input() filterlabel: string;
   @Input() id: string;
   @Input() item: string;
   @Input() items: Array<string>;
@@ -28,11 +28,9 @@ export class FilterinputbarComponent implements OnInit, OnChanges {
   public onFilterButtonClick() {
     if( this.items.includes(FilterinputbarComponent.currentItem)){
         FilterinputbarComponent.currentTimestamp=FilterinputbarComponent.currentItem
-      console.log("Timestamp switched")
     }else{
       FilterinputbarComponent.currentItem = this.item;
       this.onFilterButtonClicked.emit();
-      console.log("filter switched")
     }
   }
 

--- a/bogenliga/src/app/modules/shared/components/selectionlists/filterinputbar/filterinputbar.component.ts
+++ b/bogenliga/src/app/modules/shared/components/selectionlists/filterinputbar/filterinputbar.component.ts
@@ -34,6 +34,7 @@ export class FilterinputbarComponent implements OnInit, OnChanges {
     }else{
       FilterinputbarComponent.currentStatus = FilterinputbarComponent.currentItem
     }
+    this.onFilterButtonClicked.emit();
   }
 
   protected readonly MigrationComponent = MigrationComponent;

--- a/bogenliga/src/app/modules/shared/components/selectionlists/filterinputbar/filterinputbar.component.ts
+++ b/bogenliga/src/app/modules/shared/components/selectionlists/filterinputbar/filterinputbar.component.ts
@@ -22,7 +22,7 @@ export class FilterinputbarComponent implements OnInit, OnChanges {
   @Input() items: Array<string>;
 
   @Output() public onFilterButtonClicked = new EventEmitter<string>();
-  public timestamps = ["letzter Monat", "letzten drei Monate", "letzten sechs Monate", "im letzten Jahr", "unbegrenzt"];
+  public timestamps = ["letzter Monat", "letzten drei Monate", "letzten sechs Monate", "im letzten Jahr", "alle"];
   public static currentItem:string;
   public static currentStatus:string;
   public static currentTimestamp:string;

--- a/bogenliga/src/app/modules/shared/components/selectionlists/filterinputbar/filterinputbar.component.ts
+++ b/bogenliga/src/app/modules/shared/components/selectionlists/filterinputbar/filterinputbar.component.ts
@@ -22,11 +22,18 @@ export class FilterinputbarComponent implements OnInit, OnChanges {
   @Input() items: Array<string>;
 
   @Output() public onFilterButtonClicked = new EventEmitter<string>();
-
+  public timestamps = ["letzter Monat", "letzten drei Monate", "letzten sechs Monate", "im letzten Jahr", "Alle"];
   public static currentItem:string;
+  public static currentTimestamp:string;
   public onFilterButtonClick() {
-    FilterinputbarComponent.currentItem = this.item;
-    this.onFilterButtonClicked.emit();
+    if( this.items.includes(FilterinputbarComponent.currentItem)){
+        FilterinputbarComponent.currentTimestamp=FilterinputbarComponent.currentItem
+      console.log("Timestamp switched")
+    }else{
+      FilterinputbarComponent.currentItem = this.item;
+      this.onFilterButtonClicked.emit();
+      console.log("filter switched")
+    }
   }
 
   protected readonly MigrationComponent = MigrationComponent;

--- a/bogenliga/src/app/modules/shared/shared.module.ts
+++ b/bogenliga/src/app/modules/shared/shared.module.ts
@@ -63,6 +63,9 @@ import {
   VeranstaltungenButtonComponent
 } from '@shared/components/buttons/veranstaltungen-button/veranstaltungen-button.component';
 import {FilterinputbarComponent} from '@shared/components/selectionlists/filterinputbar/filterinputbar.component';
+import {
+  FilterTimestampInputbarComponent
+} from '@shared/components/selectionlists/filterTimestampInputbar/filterTimestampInputbar.component';
 
 
 @NgModule({
@@ -108,6 +111,7 @@ import {FilterinputbarComponent} from '@shared/components/selectionlists/filteri
     QuicksearchListComponent,
     QuicksearchComponent,
     FilterinputbarComponent,
+    FilterTimestampInputbarComponent,
     DownloadButtonComponent,
     SimpleOverviewDialogComponent,
     DoubleSelectionlistComponent,
@@ -156,6 +160,7 @@ import {FilterinputbarComponent} from '@shared/components/selectionlists/filteri
     QuicksearchListComponent,
     QuicksearchComponent,
     FilterinputbarComponent,
+    FilterTimestampInputbarComponent,
     DownloadButtonComponent,
     DoubleSelectionlistComponent,
     BogenkontrolllisteDownloadComponent,

--- a/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.html
@@ -9,13 +9,18 @@
                      [isCustomActionButton]=true
                      [changePageButtons]=true
                      (onCustomActionButtonClicked)="startMigration()"
+                     (onDeleteButtonClicked)="deleteEntries()"
                      [showFilterButton] =true
                      [showStatusFilter]=true
                      (onPreviousPageButtonClicked)="previousPageButton()"
                      (onNextPageButtonClicked)="nextPageButton()"
                      [filterItem]="currentStatus"
                      [filterItems]="statusArray"
+                     [timeItem]="currentTimestamp"
+                     [timeItems]="timestampArray"
                      (onFilterClicked) = "selectFilterForStatus()"
+                     (onTimestampClicked)="selectTimestamp()"
+
 
 >
  <div (mouseover)="onMouseOver($event)"></div>

--- a/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.html
@@ -20,6 +20,8 @@
                      [timeItems]="timestampArray"
                      [timestampDropdownLabel]="timestampDropdownLable"
                      [filterDropdownLabel]="filterDropdownLable"
+                     [cypressTagTimestamp]="cypressTagTimestamp"
+                     [cypressTagStatus]="cypressTagStatus"
                      (onFilterClicked) = "selectFilterForStatus()"
                      (onTimestampClicked)="selectTimestamp()"
 

--- a/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.html
@@ -18,6 +18,8 @@
                      [filterItems]="statusArray"
                      [timeItem]="currentTimestamp"
                      [timeItems]="timestampArray"
+                     [timestampDropdownLabel]="timestampDropdownLable"
+                     [filterDropdownLabel]="filterDropdownLable"
                      (onFilterClicked) = "selectFilterForStatus()"
                      (onTimestampClicked)="selectTimestamp()"
 

--- a/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.ts
@@ -37,7 +37,7 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
   public currentStatus: string = "Fehlgeschlagen";
   public statusArray: Array<string> = ["Fehlgeschlagen", "Erfolgreich", "Laufend", "Neu", "Alle"];
   public currentTimestamp: string = "letzter Monat";
-  public timestampArray: Array<string> = ["letzter Monat", "letzten drei Monate", "letzten sechs Monate", "im letzten Jahr", "unbegrenzt"];
+  public timestampArray: Array<string> = ["letzter Monat", "letzten drei Monate", "letzten sechs Monate", "im letzten Jahr", "alle"];
   public ActionButtonColors = ActionButtonColors;
   public timestampDropdownLable = "Zeitstempel";
   public filterDropdownLable ="Status";

--- a/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.ts
@@ -230,7 +230,7 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
             if (myNotification.userAction === NotificationUserAction.ACCEPTED) {
               this.offsetMultiplictor = 0;
               this.queryPageLimit = 500;
-              this.MigrationDataProvider.findDeleteEntries(this.currentStatus,this.currentTimestamp)
+              this.MigrationDataProvider.deleteEntries(this.currentStatus,this.currentTimestamp)
                   .then((response: BogenligaResponse<TriggerDTO[]>) => {
                     this.handleLoadTableRowsSuccess(response);
                     console.log(response);

--- a/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.ts
@@ -78,7 +78,7 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
 
 
   private loadTableRows() {
-    this.MigrationDataProvider.findErrors(this.offsetMultiplictor,this.queryPageLimit)
+    this.MigrationDataProvider.findErrors(this.offsetMultiplictor,this.queryPageLimit,this.currentTimestamp)
         .then((response: BogenligaResponse<TriggerDTO[]>) => {
           this.handleLoadTableRowsSuccess(response);
           console.log(response);
@@ -87,7 +87,6 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
   }
 
   public startMigration() {
-
     try {
       this.notificationService.showNotification({
         id:          'Migrationslauf starten?',
@@ -128,7 +127,7 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
         block:    'start'
       });
     }
-    this.filterForStatus(this.offsetMultiplictor,this.queryPageLimit)
+    this.filterForStatus(this.offsetMultiplictor,this.queryPageLimit,this.currentTimestamp)
   }
   public nextPageButton(){
     this.offsetMultiplictor++;
@@ -139,16 +138,20 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
         block: 'start'
       });
     }
-    this.filterForStatus(this.offsetMultiplictor,this.queryPageLimit)
+    this.filterForStatus(this.offsetMultiplictor,this.queryPageLimit,this.currentTimestamp)
   }
   selectTimestamp() {
-
+    this.currentTimestamp = FilterinputbarComponent.currentTimestamp
+    console.log('Timestamp switched to ' + this.currentTimestamp + ' and resetted OffsetMultiplicator')
+    this.queryPageLimit= 500;
+    this.offsetMultiplictor=0;
+    this.filterForStatus(this.offsetMultiplictor,this.queryPageLimit,this.currentTimestamp)
   }
-  filterForStatus(multiplicator: number,pagelimit: number) {
+  filterForStatus(multiplicator: number,pagelimit: number,timestamp:string) {
     try {
         switch(this.currentStatus) {
           case "Fehlgeschlagen":
-            this.MigrationDataProvider.findErrors(multiplicator,pagelimit)
+            this.MigrationDataProvider.findErrors(multiplicator,pagelimit,timestamp)
                 .then((response: BogenligaResponse<TriggerDTO[]>) => {
                   this.handleLoadTableRowsSuccess(response);
                   console.log(response);
@@ -156,7 +159,7 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
                 .catch((response: BogenligaResponse<TriggerDTO[]>) => this.handleLoadTableRowsFailure(response));
             break;
           case "Alle":
-            this.MigrationDataProvider.findAllWithPages(multiplicator,pagelimit)
+            this.MigrationDataProvider.findAllWithPages(multiplicator,pagelimit,timestamp)
                 .then((response: BogenligaResponse<TriggerDTO[]>) => {
                   this.handleLoadTableRowsSuccess(response);
                   console.log(response);
@@ -164,7 +167,7 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
                 .catch((response: BogenligaResponse<TriggerDTO[]>) => this.handleLoadTableRowsFailure(response));
             break;
           case "Erfolgreich":
-            this.MigrationDataProvider.findSuccessed(multiplicator,pagelimit)
+            this.MigrationDataProvider.findSuccessed(multiplicator,pagelimit,timestamp)
                 .then((response: BogenligaResponse<TriggerDTO[]>) => {
                   this.handleLoadTableRowsSuccess(response);
                   console.log(response);
@@ -172,7 +175,7 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
                 .catch((response: BogenligaResponse<TriggerDTO[]>) => this.handleLoadTableRowsFailure(response));
             break;
           case "Laufend":
-            this.MigrationDataProvider.findInProgress(multiplicator,pagelimit)
+            this.MigrationDataProvider.findInProgress(multiplicator,pagelimit,timestamp)
                 .then((response: BogenligaResponse<TriggerDTO[]>) => {
                   this.handleLoadTableRowsSuccess(response);
                   console.log(response);
@@ -180,7 +183,7 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
                 .catch((response: BogenligaResponse<TriggerDTO[]>) => this.handleLoadTableRowsFailure(response));
             break;
           case "Neu":
-            this.MigrationDataProvider.findNews(multiplicator,pagelimit)
+            this.MigrationDataProvider.findNews(multiplicator,pagelimit,timestamp)
                 .then((response: BogenligaResponse<TriggerDTO[]>) => {
                   this.handleLoadTableRowsSuccess(response);
                   console.log(response);
@@ -204,11 +207,11 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
     }
   }
   selectFilterForStatus(){
-    this.currentStatus = FilterinputbarComponent.currentItem
-    console.log('Status switched to ' + this.currentStatus + ' and resetet OffsetMultiplicator')
+    this.currentStatus = FilterinputbarComponent.currentStatus
+    console.log('Status switched to ' + this.currentStatus + ' and resetted OffsetMultiplicator')
     this.queryPageLimit= 500;
     this.offsetMultiplictor=0;
-    this.filterForStatus(this.offsetMultiplictor,this.queryPageLimit)
+    this.filterForStatus(this.offsetMultiplictor,this.queryPageLimit,this.currentTimestamp)
   }
   deleteEntries() {
     try {
@@ -227,13 +230,13 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
             if (myNotification.userAction === NotificationUserAction.ACCEPTED) {
               this.offsetMultiplictor = 0;
               this.queryPageLimit = 500;
-              this.MigrationDataProvider.findDeleteEntries()
+              this.MigrationDataProvider.findDeleteEntries(this.currentStatus,this.currentTimestamp)
                   .then((response: BogenligaResponse<TriggerDTO[]>) => {
                     this.handleLoadTableRowsSuccess(response);
                     console.log(response);
                   })
                   .catch((response: BogenligaResponse<TriggerDTO[]>) => this.handleLoadTableRowsFailure(response));
-              this.filterForStatus(this.offsetMultiplictor,this.queryPageLimit);
+              this.filterForStatus(this.offsetMultiplictor,this.queryPageLimit,this.currentTimestamp);
             }
           });
     } catch (e) {

--- a/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.ts
@@ -37,7 +37,7 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
   public currentStatus: string = "Fehlgeschlagen";
   public statusArray: Array<string> = ["Fehlgeschlagen", "Erfolgreich", "Laufend", "Neu", "Alle"];
   public currentTimestamp: string = "letzter Monat";
-  public timestampArray: Array<string> = ["letzter Monat", "letzten drei Monate", "letzten sechs Monate", "im letzten Jahr", "Alle"];
+  public timestampArray: Array<string> = ["letzter Monat", "letzten drei Monate", "letzten sechs Monate", "im letzten Jahr", "unbegrenzt"];
   public ActionButtonColors = ActionButtonColors;
   public timestampDropdownLable = "Zeitstempel";
   public filterDropdownLable ="Status";
@@ -149,50 +149,50 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
   }
   filterForStatus(multiplicator: number,pagelimit: number,timestamp:string) {
     try {
-        switch(this.currentStatus) {
-          case "Fehlgeschlagen":
-            this.MigrationDataProvider.findErrors(multiplicator,pagelimit,timestamp)
-                .then((response: BogenligaResponse<TriggerDTO[]>) => {
-                  this.handleLoadTableRowsSuccess(response);
-                  console.log(response);
-                })
-                .catch((response: BogenligaResponse<TriggerDTO[]>) => this.handleLoadTableRowsFailure(response));
-            break;
-          case "Alle":
-            this.MigrationDataProvider.findAllWithPages(multiplicator,pagelimit,timestamp)
-                .then((response: BogenligaResponse<TriggerDTO[]>) => {
-                  this.handleLoadTableRowsSuccess(response);
-                  console.log(response);
-                })
-                .catch((response: BogenligaResponse<TriggerDTO[]>) => this.handleLoadTableRowsFailure(response));
-            break;
-          case "Erfolgreich":
-            this.MigrationDataProvider.findSuccessed(multiplicator,pagelimit,timestamp)
-                .then((response: BogenligaResponse<TriggerDTO[]>) => {
-                  this.handleLoadTableRowsSuccess(response);
-                  console.log(response);
-                })
-                .catch((response: BogenligaResponse<TriggerDTO[]>) => this.handleLoadTableRowsFailure(response));
-            break;
-          case "Laufend":
-            this.MigrationDataProvider.findInProgress(multiplicator,pagelimit,timestamp)
-                .then((response: BogenligaResponse<TriggerDTO[]>) => {
-                  this.handleLoadTableRowsSuccess(response);
-                  console.log(response);
-                })
-                .catch((response: BogenligaResponse<TriggerDTO[]>) => this.handleLoadTableRowsFailure(response));
-            break;
-          case "Neu":
-            this.MigrationDataProvider.findNews(multiplicator,pagelimit,timestamp)
-                .then((response: BogenligaResponse<TriggerDTO[]>) => {
-                  this.handleLoadTableRowsSuccess(response);
-                  console.log(response);
-                })
-                .catch((response: BogenligaResponse<TriggerDTO[]>) => this.handleLoadTableRowsFailure(response));
-            break;
-          default:
-            console.log('ERROR WHILE SELECTING STATUS')
-            break;
+      switch(this.currentStatus) {
+        case "Fehlgeschlagen":
+          this.MigrationDataProvider.findErrors(multiplicator,pagelimit,timestamp)
+              .then((response: BogenligaResponse<TriggerDTO[]>) => {
+                this.handleLoadTableRowsSuccess(response);
+                console.log(response);
+              })
+              .catch((response: BogenligaResponse<TriggerDTO[]>) => this.handleLoadTableRowsFailure(response));
+          break;
+        case "Alle":
+          this.MigrationDataProvider.findAllWithPages(multiplicator,pagelimit,timestamp)
+              .then((response: BogenligaResponse<TriggerDTO[]>) => {
+                this.handleLoadTableRowsSuccess(response);
+                console.log(response);
+              })
+              .catch((response: BogenligaResponse<TriggerDTO[]>) => this.handleLoadTableRowsFailure(response));
+          break;
+        case "Erfolgreich":
+          this.MigrationDataProvider.findSuccessed(multiplicator,pagelimit,timestamp)
+              .then((response: BogenligaResponse<TriggerDTO[]>) => {
+                this.handleLoadTableRowsSuccess(response);
+                console.log(response);
+              })
+              .catch((response: BogenligaResponse<TriggerDTO[]>) => this.handleLoadTableRowsFailure(response));
+          break;
+        case "Laufend":
+          this.MigrationDataProvider.findInProgress(multiplicator,pagelimit,timestamp)
+              .then((response: BogenligaResponse<TriggerDTO[]>) => {
+                this.handleLoadTableRowsSuccess(response);
+                console.log(response);
+              })
+              .catch((response: BogenligaResponse<TriggerDTO[]>) => this.handleLoadTableRowsFailure(response));
+          break;
+        case "Neu":
+          this.MigrationDataProvider.findNews(multiplicator,pagelimit,timestamp)
+              .then((response: BogenligaResponse<TriggerDTO[]>) => {
+                this.handleLoadTableRowsSuccess(response);
+                console.log(response);
+              })
+              .catch((response: BogenligaResponse<TriggerDTO[]>) => this.handleLoadTableRowsFailure(response));
+          break;
+        default:
+          console.log('ERROR WHILE SELECTING STATUS')
+          break;
       }
     } catch (e) {
       this.notificationService.showNotification({
@@ -236,7 +236,6 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
                     console.log(response);
                   })
                   .catch((response: BogenligaResponse<TriggerDTO[]>) => this.handleLoadTableRowsFailure(response));
-              this.filterForStatus(this.offsetMultiplictor,this.queryPageLimit,this.currentTimestamp);
             }
           });
     } catch (e) {

--- a/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.ts
@@ -19,6 +19,9 @@ import {ActionButtonColors} from '@shared/components/buttons/button/actionbutton
 import {TriggerDTO} from '@verwaltung/types/datatransfer/trigger-dto.class';
 import {TableRow} from '@shared/components/tables/types/table-row.class';
 import {FilterinputbarComponent} from '@shared/components/selectionlists/filterinputbar/filterinputbar.component';
+import {
+  FilterTimestampInputbarComponent
+} from '@shared/components/selectionlists/filterTimestampInputbar/filterTimestampInputbar.component';
 
 export const NOTIFICATION_DELETE_MIGRATION = 'migration_delete';
 @Component({
@@ -41,6 +44,8 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
   public ActionButtonColors = ActionButtonColors;
   public timestampDropdownLable = "Zeitstempel";
   public filterDropdownLable ="Status";
+  public cypressTagStatus ="status-filter-selection";
+  public cypressTagTimestamp = "timestamp-filter-selection";
   public offsetMultiplictor = 0;
   public queryPageLimit = 500;
 
@@ -141,7 +146,7 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
     this.filterForStatus(this.offsetMultiplictor,this.queryPageLimit,this.currentTimestamp)
   }
   selectTimestamp() {
-    this.currentTimestamp = FilterinputbarComponent.currentTimestamp
+    this.currentTimestamp = FilterTimestampInputbarComponent.currentTimestamp
     console.log('Timestamp switched to ' + this.currentTimestamp + ' and resetted OffsetMultiplicator')
     this.queryPageLimit= 500;
     this.offsetMultiplictor=0;

--- a/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/migration/migration.component.ts
@@ -39,8 +39,11 @@ export class MigrationComponent extends CommonComponentDirective implements OnIn
   public currentTimestamp: string = "letzter Monat";
   public timestampArray: Array<string> = ["letzter Monat", "letzten drei Monate", "letzten sechs Monate", "im letzten Jahr", "Alle"];
   public ActionButtonColors = ActionButtonColors;
+  public timestampDropdownLable = "Zeitstempel";
+  public filterDropdownLable ="Status";
   public offsetMultiplictor = 0;
   public queryPageLimit = 500;
+
 
   constructor(private MigrationDataProvider: MigrationProviderService,
     private userProvider: UserProfileDataProviderService,

--- a/bogenliga/src/app/modules/verwaltung/services/migration-data-provider.service.ts
+++ b/bogenliga/src/app/modules/verwaltung/services/migration-data-provider.service.ts
@@ -168,7 +168,7 @@ export class MigrationProviderService extends DataProviderService {
   private changeTimestampToInterval(timestamp:string):string{
     let interval:string;
     switch (timestamp){
-      case 'Alle':
+      case 'unbegrenzt':
         interval = "20 YEAR"
         break;
       case 'letzter Monat':

--- a/bogenliga/src/app/modules/verwaltung/services/migration-data-provider.service.ts
+++ b/bogenliga/src/app/modules/verwaltung/services/migration-data-provider.service.ts
@@ -143,24 +143,24 @@ export class MigrationProviderService extends DataProviderService {
           });
     });
   }
-  public findDeleteEntries(status: string,timestamp:string):Promise<BogenligaResponse<TriggerDO[]>> {
+  public deleteEntries(status: string,timestamp:string):Promise<BogenligaResponse<TriggerDO[]>> {
     // return promise
     // sign in success -> resolve promise
     // sign in failure -> reject promise with result
     const dateInterval = this.changeTimestampToInterval(timestamp);
     return new Promise((resolve, reject) => {
-      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('deleteEntries?status=' + status + '&dateInterval=' + dateInterval).build())
-          .then((data: VersionedDataTransferObject[]) => {
-            resolve({result: RequestResult.SUCCESS, payload: fromPayloadArray(data)});
-          }, (error: HttpErrorResponse) => {
+      this.restClient.DELETE<any>(new UriBuilder().fromPath(this.getUrl()).path('deleteEntries?status=' + status + '&dateInterval=' + dateInterval).build())
+          .then(() => {
+            resolve({ result: RequestResult.SUCCESS});
+          })
+          .catch((error: HttpErrorResponse) => {
             if (error.status === 0) {
-              reject({result: RequestResult.CONNECTION_PROBLEM});
+              reject({ result: RequestResult.CONNECTION_PROBLEM });
             } else {
-              reject({result: RequestResult.FAILURE});
+              reject({ result: RequestResult.FAILURE });
             }
           });
     });
-
   }
   public startMigration() {
     this.restClient.GET(new UriBuilder().fromPath(this.getUrl()).path('buttonSync').build())

--- a/bogenliga/src/app/modules/verwaltung/services/migration-data-provider.service.ts
+++ b/bogenliga/src/app/modules/verwaltung/services/migration-data-provider.service.ts
@@ -138,7 +138,24 @@ export class MigrationProviderService extends DataProviderService {
           });
     });
   }
+  public findDeleteEntries(): Promise<BogenligaResponse<TriggerDO[]>> {
+    // return promise
+    // sign in success -> resolve promise
+    // sign in failure -> reject promise with result
+    return new Promise((resolve, reject) => {
+      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('deleteEntries').build())
+          .then((data: VersionedDataTransferObject[]) => {
+            resolve({result: RequestResult.SUCCESS, payload: fromPayloadArray(data)});
+          }, (error: HttpErrorResponse) => {
 
+            if (error.status === 0) {
+              reject({result: RequestResult.CONNECTION_PROBLEM});
+            } else {
+              reject({result: RequestResult.FAILURE});
+            }
+          });
+    });
+  }
   public startMigration() {
     this.restClient.GET(new UriBuilder().fromPath(this.getUrl()).path('buttonSync').build())
   }

--- a/bogenliga/src/app/modules/verwaltung/services/migration-data-provider.service.ts
+++ b/bogenliga/src/app/modules/verwaltung/services/migration-data-provider.service.ts
@@ -46,12 +46,13 @@ export class MigrationProviderService extends DataProviderService {
     });
   }
 
-  public findSuccessed(offsetMultiplicator:number,queryPageLimit: number): Promise<BogenligaResponse<TriggerDO[]>> {
+  public findSuccessed(offsetMultiplicator:number,queryPageLimit: number, timestamp:string): Promise<BogenligaResponse<TriggerDO[]>> {
     // return promise
     // sign in success -> resolve promise
     // sign in failure -> reject promise with result
+    const dateInterval = this.changeTimestampToInterval(timestamp);
     return new Promise((resolve, reject) => {
-      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('findSuccessed?offsetMultiplicator=' + offsetMultiplicator.toString() + '&queryPageLimit=' + queryPageLimit.toString()).build())
+      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('findSuccessed?offsetMultiplicator=' + offsetMultiplicator.toString() + '&queryPageLimit=' + queryPageLimit.toString() + '&dateInterval=' + dateInterval.toString()).build())
           .then((data: VersionedDataTransferObject[]) => {
             resolve({result: RequestResult.SUCCESS, payload: fromPayloadArray(data)});
           }, (error: HttpErrorResponse) => {
@@ -64,12 +65,13 @@ export class MigrationProviderService extends DataProviderService {
           });
     });
   }
-  public findAllWithPages(offsetMultiplicator:number,queryPageLimit: number): Promise<BogenligaResponse<TriggerDO[]>> {
+  public findAllWithPages(offsetMultiplicator:number,queryPageLimit: number, timestamp:string): Promise<BogenligaResponse<TriggerDO[]>> {
     // return promise
     // sign in success -> resolve promise
     // sign in failure -> reject promise with result
+    const dateInterval = this.changeTimestampToInterval(timestamp);
     return new Promise((resolve, reject) => {
-      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('findAllWithPages?offsetMultiplicator=' + offsetMultiplicator.toString() + '&queryPageLimit=' + queryPageLimit.toString()).build()
+      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('findAllWithPages?offsetMultiplicator=' + offsetMultiplicator.toString() + '&queryPageLimit=' + queryPageLimit.toString() + '&dateInterval=' + dateInterval.toString()).build()
       )
           .then((data: VersionedDataTransferObject[]) => {
             resolve({result: RequestResult.SUCCESS, payload: fromPayloadArray(data)});
@@ -83,12 +85,13 @@ export class MigrationProviderService extends DataProviderService {
           });
     });
   }
-  public findErrors(offsetMultiplicator:number,queryPageLimit: number): Promise<BogenligaResponse<TriggerDO[]>> {
+  public findErrors(offsetMultiplicator:number,queryPageLimit: number, timestamp:string): Promise<BogenligaResponse<TriggerDO[]>> {
     // return promise
     // sign in success -> resolve promise
     // sign in failure -> reject promise with result
+    const dateInterval = this.changeTimestampToInterval(timestamp);
     return new Promise((resolve, reject) => {
-      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('findErrors?offsetMultiplicator=' + offsetMultiplicator.toString() + '&queryPageLimit=' + queryPageLimit.toString()).build()
+      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('findErrors?offsetMultiplicator=' + offsetMultiplicator.toString() + '&queryPageLimit=' + queryPageLimit.toString() + '&dateInterval=' + dateInterval.toString()).build()
       )
           .then((data: VersionedDataTransferObject[]) => {
             resolve({result: RequestResult.SUCCESS, payload: fromPayloadArray(data)});
@@ -102,12 +105,13 @@ export class MigrationProviderService extends DataProviderService {
           });
     });
   }
-  public findInProgress(offsetMultiplicator:number,queryPageLimit: number): Promise<BogenligaResponse<TriggerDO[]>> {
+  public findInProgress(offsetMultiplicator:number,queryPageLimit: number, timestamp:string): Promise<BogenligaResponse<TriggerDO[]>> {
     // return promise
     // sign in success -> resolve promise
     // sign in failure -> reject promise with result
+    const dateInterval = this.changeTimestampToInterval(timestamp);
     return new Promise((resolve, reject) => {
-      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('findInProgress?offsetMultiplicator=' + offsetMultiplicator.toString() + '&queryPageLimit=' + queryPageLimit.toString()).build())
+      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('findInProgress?offsetMultiplicator=' + offsetMultiplicator.toString() + '&queryPageLimit=' + queryPageLimit.toString() + '&dateInterval=' + dateInterval.toString()).build())
           .then((data: VersionedDataTransferObject[]) => {
             resolve({result: RequestResult.SUCCESS, payload: fromPayloadArray(data)});
           }, (error: HttpErrorResponse) => {
@@ -120,12 +124,13 @@ export class MigrationProviderService extends DataProviderService {
           });
     });
   }
-  public findNews(offsetMultiplicator:number,queryPageLimit: number): Promise<BogenligaResponse<TriggerDO[]>> {
+  public findNews(offsetMultiplicator:number,queryPageLimit: number, timestamp:string): Promise<BogenligaResponse<TriggerDO[]>> {
     // return promise
     // sign in success -> resolve promise
     // sign in failure -> reject promise with result
+    const dateInterval = this.changeTimestampToInterval(timestamp);
     return new Promise((resolve, reject) => {
-      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('findNews?offsetMultiplicator=' + offsetMultiplicator.toString() + '&queryPageLimit=' + queryPageLimit.toString()).build())
+      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('findNews?offsetMultiplicator=' + offsetMultiplicator.toString() + '&queryPageLimit=' + queryPageLimit.toString() + '&dateInterval=' + dateInterval.toString()).build())
           .then((data: VersionedDataTransferObject[]) => {
             resolve({result: RequestResult.SUCCESS, payload: fromPayloadArray(data)});
           }, (error: HttpErrorResponse) => {
@@ -138,16 +143,16 @@ export class MigrationProviderService extends DataProviderService {
           });
     });
   }
-  public findDeleteEntries(): Promise<BogenligaResponse<TriggerDO[]>> {
+  public findDeleteEntries(status: string,timestamp:string):Promise<BogenligaResponse<TriggerDO[]>> {
     // return promise
     // sign in success -> resolve promise
     // sign in failure -> reject promise with result
+    const dateInterval = this.changeTimestampToInterval(timestamp);
     return new Promise((resolve, reject) => {
-      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('deleteEntries').build())
+      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('deleteEntries?status=' + status + '&dateInterval=' + dateInterval).build())
           .then((data: VersionedDataTransferObject[]) => {
             resolve({result: RequestResult.SUCCESS, payload: fromPayloadArray(data)});
           }, (error: HttpErrorResponse) => {
-
             if (error.status === 0) {
               reject({result: RequestResult.CONNECTION_PROBLEM});
             } else {
@@ -155,8 +160,30 @@ export class MigrationProviderService extends DataProviderService {
             }
           });
     });
+
   }
   public startMigration() {
     this.restClient.GET(new UriBuilder().fromPath(this.getUrl()).path('buttonSync').build())
+  }
+  private changeTimestampToInterval(timestamp:string):string{
+    let interval:string;
+    switch (timestamp){
+      case 'Alle':
+        interval = "20 YEAR"
+        break;
+      case 'letzter Monat':
+        interval = "1 MONTH"
+        break;
+      case 'letzten drei Monate':
+        interval = "3 MONTH"
+        break;
+      case 'letzten sechs Monate':
+        interval = "6 MONTH"
+        break;
+      case 'im letzten Jahr':
+        interval = "12 MONTH"
+        break;
+    }
+    return interval;
   }
 }

--- a/bogenliga/src/app/modules/verwaltung/services/migration-data-provider.service.ts
+++ b/bogenliga/src/app/modules/verwaltung/services/migration-data-provider.service.ts
@@ -168,7 +168,7 @@ export class MigrationProviderService extends DataProviderService {
   private changeTimestampToInterval(timestamp:string):string{
     let interval:string;
     switch (timestamp){
-      case 'unbegrenzt':
+      case 'alle':
         interval = "20 YEAR"
         break;
       case 'letzter Monat':

--- a/bogenliga/src/app/modules/verwaltung/services/migration-data-provider.service.ts
+++ b/bogenliga/src/app/modules/verwaltung/services/migration-data-provider.service.ts
@@ -52,7 +52,8 @@ export class MigrationProviderService extends DataProviderService {
     // sign in failure -> reject promise with result
     const dateInterval = this.changeTimestampToInterval(timestamp);
     return new Promise((resolve, reject) => {
-      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('findSuccessed?offsetMultiplicator=' + offsetMultiplicator.toString() + '&queryPageLimit=' + queryPageLimit.toString() + '&dateInterval=' + dateInterval.toString()).build())
+      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('findSuccessed?offsetMultiplicator=' + offsetMultiplicator.toString()
+        + '&queryPageLimit=' + queryPageLimit.toString() + '&dateInterval=' + dateInterval.toString()).build())
           .then((data: VersionedDataTransferObject[]) => {
             resolve({result: RequestResult.SUCCESS, payload: fromPayloadArray(data)});
           }, (error: HttpErrorResponse) => {


### PR DESCRIPTION
Wir haben das löschen vom Protokoll der Datenmigration umgesetzt, man kann jetzt ebenfalls für Zeitstempel filtern. Nachdem man alles gefiltert hat kann man alle gefilterten Protokolle mit einem Button löschen lassen.
Tests wurden auch implementiert.