### PR TITLE
Hinzufügen eines Hinweises bei "unsure" treffern.

### DIFF
--- a/bogenliga/src/app/modules/spotter/components/interface/interface.component.html
+++ b/bogenliga/src/app/modules/spotter/components/interface/interface.component.html
@@ -148,7 +148,7 @@
         <button type="button" class="btn btn-secondary" style="font-size: 25px;" (click)="onSave()">{{'SPOTTER.COMPONENTS.BUTTON.SAVE'| translate}}</button>
       </div>
     </div>
-    <div *ngIf="!spotting && !editing" class="row h-25 align-items-center" style="padding: 25px 0px;">
+    <div *ngIf="!spotting && !editing && !allowedToSaveSet" class="row h-25 align-items-center" style="padding: 25px 0px;">
       <div class="col-6 p-0 text-center">
         <button type="button" class="button-footer" (click)="onNextSet()" [disabled]="!match.set().canFinish()">{{'SPOTTER.COMPONENTS.BUTTON.NEACHSTERSATZ'| translate}}</button>
       </div>

--- a/bogenliga/src/app/modules/spotter/components/interface/interface.component.html
+++ b/bogenliga/src/app/modules/spotter/components/interface/interface.component.html
@@ -124,6 +124,16 @@
       </div>
     </div>
     <!--FOOTER-->
+    <div *ngIf="allowedToSaveSet" class="info-box-unsure">
+      <span class="info-icon-unsure">
+        <div class="info-content-unsure">
+          <strong>Hinweis:</strong>
+          <p>
+              Sie müssen alle "unsicheren" treffen, als "sicher" markieren um zum nächsten Satz bzw. um Match zu beenden.
+          </p>
+        </div>
+      </span>
+    </div>
     <div *ngIf="spotting || editing" class="row h-25 align-items-center" style="padding: 20px 0px;">
       <div class="col-4 text-center align-center">
         <button type="button" class="btn btn-secondary" style="font-size: 25px;" (click)="onBack()">{{'SPOTTER.COMPONENTS.BUTTON.BACK'| translate}}</button>
@@ -138,7 +148,7 @@
         <button type="button" class="btn btn-secondary" style="font-size: 25px;" (click)="onSave()">{{'SPOTTER.COMPONENTS.BUTTON.SAVE'| translate}}</button>
       </div>
     </div>
-    <div *ngIf="!spotting && !editing" class="row h-25 align-items-center" style="padding: 25px 0px;">
+    <div *ngIf="!spotting && !editing && !allowedToSaveSet" class="row h-25 align-items-center" style="padding: 25px 0px;">
       <div class="col-6 p-0 text-center">
         <button type="button" class="button-footer" (click)="onNextSet()" [disabled]="!match.set().canFinish()">{{'SPOTTER.COMPONENTS.BUTTON.NEACHSTERSATZ'| translate}}</button>
       </div>

--- a/bogenliga/src/app/modules/spotter/components/interface/interface.component.html
+++ b/bogenliga/src/app/modules/spotter/components/interface/interface.component.html
@@ -124,6 +124,16 @@
       </div>
     </div>
     <!--FOOTER-->
+    <div *ngIf="allowedToSaveSet" class="info-box-unsure">
+      <span class="info-icon">
+        <div class="info-content">
+          <strong>Hinweis:</strong>
+          <p>
+              Sie müssen alle "unsicheren" treffen, als "sicher" markieren um zum nächsten Satz bzw. um Match zu beenden.
+          </p>
+        </div>
+      </span>
+    </div>
     <div *ngIf="spotting || editing" class="row h-25 align-items-center" style="padding: 20px 0px;">
       <div class="col-4 text-center align-center">
         <button type="button" class="btn btn-secondary" style="font-size: 25px;" (click)="onBack()">{{'SPOTTER.COMPONENTS.BUTTON.BACK'| translate}}</button>
@@ -138,7 +148,7 @@
         <button type="button" class="btn btn-secondary" style="font-size: 25px;" (click)="onSave()">{{'SPOTTER.COMPONENTS.BUTTON.SAVE'| translate}}</button>
       </div>
     </div>
-    <div *ngIf="!spotting && !editing" class="row h-25 align-items-center" style="padding: 25px 0px;">
+    <div *ngIf="!spotting && !editing && !allowedToSaveSet" class="row h-25 align-items-center" style="padding: 25px 0px;">
       <div class="col-6 p-0 text-center">
         <button type="button" class="button-footer" (click)="onNextSet()" [disabled]="!match.set().canFinish()">{{'SPOTTER.COMPONENTS.BUTTON.NEACHSTERSATZ'| translate}}</button>
       </div>

--- a/bogenliga/src/app/modules/spotter/components/interface/interface.component.scss
+++ b/bogenliga/src/app/modules/spotter/components/interface/interface.component.scss
@@ -185,3 +185,32 @@
     }
 }
 
+.info-box-unsure {
+  display: flex;
+  align-items: center;
+  background-color: #eaf4fc;
+  border: 1px solid #b5d8f1;
+  border-radius: 8px;
+  padding: 2px;
+  margin: 10px 0;
+  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+  font-family: Arial, sans-serif;
+  color: #0b5a8a;
+
+}
+
+.info-icon-unsure {
+  font-size: 24px;
+  margin-right: 10px;
+}
+
+.info-content-unsure {
+  font-size: 16px;
+  line-height: 1.4;
+}
+
+.info-content strong {
+  font-weight: bold;
+  color: #074a72;
+}
+


### PR DESCRIPTION
Was verändert wurde:
    • Nächster Satz & Match beenden wird nur angezeigt, wenn alle Treffer auf "sure" sind.
    • Hinweis wird anzeigt, bei einem oder mehren "unsure" Treffern:
        ◦ Hinweis wird über den Cache berechnet, dass heißt er verschwindet jetzt nicht wenn man aktualisiert.
        ◦ Hierzu wurde die bestehende Entwicklung für den Cache verwendet
    • Wenn mann mehrere "unsure" Treffer hat und einen dann auf "sure" setzt kam man immer in die Übersichtsseite, nun kann man alle "unsure" Treffer nacheinander auf sure setzen und springt nicht direkt wieder auf die Übersichtsseite.