### PR TITLE
Fix login initialization

### DIFF
--- a/bogenliga/src/app/modules/user/components/login/login.component.ts
+++ b/bogenliga/src/app/modules/user/components/login/login.component.ts
@@ -20,7 +20,7 @@ const LOGIN_REDIRECT_QUERY_PARAM = 'destination';
 export class LoginComponent implements OnInit {
 
   public credentials = new CredentialsDO();
-  public accessCode: '';
+  public accessCode = '';
 
   public loading = false;
   public loginResult: LoginResult = LoginResult.PENDING;


### PR DESCRIPTION
## Summary
- correct accessCode initialization to be empty string

## Testing
- `npm test --prefix bogenliga` *(fails: ng not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684293fece24832eb36d6b55ce7e5e6d