### PR TITLE
Implement recent league tracking using cookies

### DIFF
--- a/bogenliga/src/app/modules/home/components/home/home.component.html
+++ b/bogenliga/src/app/modules/home/components/home/home.component.html
@@ -5,7 +5,7 @@
     <h1 class="homeHeading">{{'HOME.HOME.WELCOME' | translate }}</h1>
     <p class="subtitle">{{ 'HOME.HOME.CONTENT' | translate }}</p>
     <div *ngIf="recentLigas.length > 0">
-      <h3>{{ 'HOME.HOME.RECENT_TITLE' | translate }}</h3>
+      <h2>{{ 'HOME.HOME.RECENT_TITLE' | translate }}</h2>
       <ul class="recent-liga-list">
         <li *ngFor="let liga of recentLigas">
           <a [routerLink]="['/home', liga.id]">{{ liga.name }}</a>

--- a/bogenliga/src/app/modules/home/components/home/home.component.html
+++ b/bogenliga/src/app/modules/home/components/home/home.component.html
@@ -4,6 +4,14 @@
   <div style="max-width: 75%; margin: 15px; padding: 5px" *ngIf="!hasLigaIDInUrl && (!hasLigaNameInUrl)" data-cy=welcome-banner>
     <h1 class="homeHeading">{{'HOME.HOME.WELCOME' | translate }}</h1>
     <p class="subtitle">{{ 'HOME.HOME.CONTENT' | translate }}</p>
+    <div *ngIf="recentLigas.length > 0">
+      <h3>{{ 'HOME.HOME.RECENT_TITLE' | translate }}</h3>
+      <ul class="recent-liga-list">
+        <li *ngFor="let liga of recentLigas">
+          <a [routerLink]="['/home', liga.id]">{{ liga.name }}</a>
+        </li>
+      </ul>
+    </div>
   </div>
 
   <!--Ligadetail Page Title-->

--- a/bogenliga/src/app/modules/home/components/home/home.component.scss
+++ b/bogenliga/src/app/modules/home/components/home/home.component.scss
@@ -22,6 +22,15 @@ h1{
 
 }
 
+.recent-liga-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.recent-liga-list li {
+  margin: 2px 0;
+}
+
 // css for Images of containers
 .mosaikImg {
   width: 80%;

--- a/bogenliga/src/app/modules/home/components/home/home.component.ts
+++ b/bogenliga/src/app/modules/home/components/home/home.component.ts
@@ -28,6 +28,7 @@ import {element} from 'protractor';
 import {SelectedLigaDataprovider} from '@shared/data-provider/SelectedLigaDataprovider';
 import {faHome} from '@fortawesome/free-solid-svg-icons';
 import {IconProp} from '@fortawesome/fontawesome-svg-core';
+import { RecentLigaService, RecentLigaEntry } from '@shared/services';
 //for notification
 import {
   CurrentUserService,
@@ -87,6 +88,7 @@ export class HomeComponent extends CommonComponentDirective implements OnInit, O
   public currentDate: number = Date.now();
   public dateHelper: string;
   public veranstaltungWettkaempfeDO: VeranstaltungWettkaempfe[] = [];
+  public recentLigas: RecentLigaEntry[] = [];
 
   public VereinsID: number;
   public providedID: number;
@@ -110,7 +112,8 @@ export class HomeComponent extends CommonComponentDirective implements OnInit, O
     private logindataprovider: LoginDataProviderService,
     private currentUserService: CurrentUserService,
     private onOfflineService: OnOfflineService,
-    private selectedLigaDataprovider: SelectedLigaDataprovider) {
+    private selectedLigaDataprovider: SelectedLigaDataprovider,
+    private recentLigaService: RecentLigaService) {
     super();
     this.sessionHandling = new SessionHandling(this.currentUserService, this.onOfflineService);
 
@@ -148,6 +151,8 @@ export class HomeComponent extends CommonComponentDirective implements OnInit, O
       this.findByVeranstalungsIds();
       this.setCorrectID();
     }
+
+    this.recentLigas = this.recentLigaService.getAll();
 
 
     //to get if of liga from route path
@@ -334,6 +339,8 @@ export class HomeComponent extends CommonComponentDirective implements OnInit, O
       this.selectedLigaDetailFileName=response.payload.ligaDetailFileName;
       this.selectedLigaDetailFileType=response.payload.ligaDetailFileType;
       this.loadedLigaData=true;
+      this.recentLigaService.add({id: this.selectedLigaID, name: this.selectedLigaName});
+      this.recentLigas = this.recentLigaService.getAll();
       if(this.hasLigaNameInUrl){
         const link = '/home/' + this.selectedLigaID;
         this.router.navigateByUrl(link);

--- a/bogenliga/src/app/modules/shared/services/index.ts
+++ b/bogenliga/src/app/modules/shared/services/index.ts
@@ -2,3 +2,4 @@ export * from './current-user';
 export * from './error-handling';
 export * from './notification';
 export * from './onoffline';
+export * from './recent-liga';

--- a/bogenliga/src/app/modules/shared/services/recent-liga/index.ts
+++ b/bogenliga/src/app/modules/shared/services/recent-liga/index.ts
@@ -1,0 +1,1 @@
+export * from './recent-liga.service';

--- a/bogenliga/src/app/modules/shared/services/recent-liga/recent-liga.service.ts
+++ b/bogenliga/src/app/modules/shared/services/recent-liga/recent-liga.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { LocalDataProviderService } from '@shared/local-data-provider';
+
+export interface RecentLigaEntry {
+  id: number;
+  name: string;
+}
+
+const STORAGE_KEY_RECENT_LIGAS = 'recent_ligas';
+const MAX_ENTRIES = 3;
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RecentLigaService {
+
+  constructor(private storage: LocalDataProviderService) { }
+
+  public add(entry: RecentLigaEntry): void {
+    let list: RecentLigaEntry[] = this.getAll();
+    list = list.filter(e => e.id !== entry.id);
+    list.unshift(entry);
+    if (list.length > MAX_ENTRIES) {
+      list = list.slice(0, MAX_ENTRIES);
+    }
+    this.storage.setPermanently(STORAGE_KEY_RECENT_LIGAS, JSON.stringify(list));
+  }
+
+  public getAll(): RecentLigaEntry[] {
+    const value = this.storage.get(STORAGE_KEY_RECENT_LIGAS);
+    try {
+      return value ? JSON.parse(value) as RecentLigaEntry[] : [];
+    } catch {
+      return [];
+    }
+  }
+}

--- a/bogenliga/src/assets/i18n/de.json
+++ b/bogenliga/src/assets/i18n/de.json
@@ -39,6 +39,7 @@
       "WELCOME": "Willkommen",
       "WETTKAEMPFE": "Unsere nächsten Wettkämpfe",
       "WETTKAMPFERSATZ": "Derzeit sind keine Wettkämpfe geplant",
+      "RECENT_TITLE": "Zuletzt besuchte Ligen",
       "FURTHER": "Weitere Infos",
       "CONTENT": "Hier finden Sie alle Informationen der Deutschen Ligen im Bogenschießen. Stöbern Sie durch die Ligen und lassen Sie sich in die Faszination des Mannschaftsbogensports ziehen.",
       "BOX1HEADING": "Schüler- und Jugend- Cup 2018",

--- a/bogenliga/src/assets/i18n/en.json
+++ b/bogenliga/src/assets/i18n/en.json
@@ -38,6 +38,7 @@
       "TITLE": "Archery League GER",
       "WELCOME": "Welcome",
       "WETTKAEMPFE": "Our next competitions",
+      "RECENT_TITLE": "Recently visited leagues",
       "FURTHER": "further information",
       "CONTENT": "On the page of Bogenliga DE, here you will find all the information of the German leagues in archery. Browse through the leagues and let yourself be drawn into the fascination of team archery.",
       "BOX1HEADING": "STUDENT CUP 2018",


### PR DESCRIPTION
## Summary
- track recently visited leagues in local storage
- expose `RecentLigaService`
- add list of recent leagues on home page
- translate heading

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842d432ab48832eb17b5af733e659a0