### PR TITLE
Fix Liga details navigation

### DIFF
--- a/bogenliga/src/app/modules/ligatabelle/components/ligatabelle/ligatabelle.component.ts
+++ b/bogenliga/src/app/modules/ligatabelle/components/ligatabelle/ligatabelle.component.ts
@@ -366,8 +366,10 @@ export class LigatabelleComponent extends CommonComponentDirective implements On
     this.router.navigateByUrl(link);
   }
   public goToLigaDetails() {
-    console.log('IDDD' + this.providedID);
-    const link = '/home/' +  this.providedID;
+    // use the ligaId of the currently selected Veranstaltung to build the route
+    const ligaId = this.selectedVeranstaltung?.ligaId ?? this.providedID;
+    console.log('IDDD' + ligaId);
+    const link = '/home/' + ligaId;
     this.router.navigateByUrl(link);
   }
 }


### PR DESCRIPTION
## Summary
- use selectedVeranstaltung.ligaId when routing to Liga details

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684a9bf475b0832ebc447195c5af50bb