### PR TITLE
Ticket #1927 - An Seitenanfang springen bei Wechsel der Schusszetteleingabe https://gitlab.gras-it.de/hsrt/swt2/-/issues/1927

### DIFF
--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
@@ -5,8 +5,7 @@ import {SchusszettelProviderService} from '../../services/schusszettel-provider.
 import {BogenligaResponse, RequestResult, UriBuilder} from '../../../shared/data-provider';
 import {MatchProviderService} from '../../services/match-provider.service';
 import {isUndefined} from '@shared/functions';
-import {ActivatedRoute, Router, NavigationEnd} from '@angular/router';
-import { filter } from 'rxjs/operators';
+import {ActivatedRoute, Router} from '@angular/router';
 import {
   Notification,
   NotificationOrigin,

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
@@ -1,11 +1,12 @@
-import {Component, Input, OnInit} from '@angular/core';
+import { Component, Input, OnInit,AfterViewInit} from '@angular/core';
 import {MatchDOExt} from '../../types/match-do-ext.class';
 import {PasseDO} from '../../types/passe-do.class';
 import {SchusszettelProviderService} from '../../services/schusszettel-provider.service';
 import {BogenligaResponse, RequestResult, UriBuilder} from '../../../shared/data-provider';
 import {MatchProviderService} from '../../services/match-provider.service';
 import {isUndefined} from '@shared/functions';
-import {ActivatedRoute, Router} from '@angular/router';
+import {ActivatedRoute, Router, NavigationEnd} from '@angular/router';
+import { filter } from 'rxjs/operators';
 import {
   Notification,
   NotificationOrigin,
@@ -46,7 +47,7 @@ const FALSCHER_SCHUETZE = '';
   templateUrl: './schusszettel.component.html',
   styleUrls:   ['./schusszettel.component.scss']
 })
-export class SchusszettelComponent implements OnInit {
+export class SchusszettelComponent implements OnInit, AfterViewInit {
 
   // Input properties for embedding in tablet zustand component
   @Input() match1Id?: number;
@@ -291,6 +292,11 @@ export class SchusszettelComponent implements OnInit {
     this.getAllWettkaempfe();
     this.getAllVeranstaltungen();
     */
+  }
+  ngAfterViewInit() {
+    setTimeout(() => {
+      document.querySelector('.wrapper')?.scrollTo(0, 0);
+    }, 0);
   }
 
   /**


### PR DESCRIPTION
Beim Navigieren zu Schusszettel ist die Scrollposition nun oben, sodass zuerst der erste Schusszettel erscheint, durch:
- Einfügen von ngAfterViewInit(): Ermöglicht scrollen nach dem Rendern
- document.querySelector('.wrapper')?.scrollTo(0,0): Ermöglicht das Scrollen vom Container.