### PR TITLE
#1939 - Mannschaften kopieren und Anlegen ohne Liga

### DIFF
--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/mannschaft-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/mannschaft-detail.component.ts
@@ -194,18 +194,11 @@ export class MannschaftDetailComponent extends CommonComponentDirective implemen
     this.saveLoading = true;
     // persist
     this.currentMannschaft.vereinId = this.currentVerein.id; // Set selected verein id// set selected veranstaltung id
-    this.currentMannschaft.benutzerId = 1;
     this.currentMannschaft.veranstaltungId = null;
     // within this method it will be checked if the mannschaftsnummer
     // is already used and an error will be displayed in case
-    if (!this.existsMannschaftsNummer(this.currentMannschaft.nummer)) {
-      // then save the new Mannschaft
-      this.saveMannschaft();
-    } else {
-      this.notificationService.showNotification(this.duplicateMannschaftsNrNotification);
-      this.saveLoading = false;
+    this.saveMannschaft();
     }
-  }
 
   public onUpdate(ignore: any): void {
     this.saveLoading = true;

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/mannschaft-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/mannschaft-detail.component.ts
@@ -194,6 +194,7 @@ export class MannschaftDetailComponent extends CommonComponentDirective implemen
     this.saveLoading = true;
     // persist
     this.currentMannschaft.vereinId = this.currentVerein.id; // Set selected verein id// set selected veranstaltung id
+    this.currentMannschaft.benutzerId = this.currentUserService.getUserId();
     this.currentMannschaft.veranstaltungId = null;
     // within this method it will be checked if the mannschaftsnummer
     // is already used and an error will be displayed in case

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.html
@@ -229,6 +229,7 @@
                       (onDownloadRueckennummerEntry)="onDownloadRueckennummer($event)"
                       (onEditEntry)="onEdit($event)"
                       (onViewEntry)="onView($event)"
+                      (onAddEntry)="onCopyMannschaft($event)"
                       [config]="config_table"
                       [loading]="loading"
                       [rows]="rows">

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.ts
@@ -52,6 +52,7 @@ const NOTIFICATION_DELETE_VEREIN_FAILURE = 'verein_detail_delete_failure';
 const NOTIFICATION_SAVE_VEREIN = 'verein_detail_save';
 const NOTIFICATION_UPDATE_VEREIN = 'verein_detail_update';
 const NOTIFICATION_DELETE_MANNSCHAFT = 'mannschaft_detail_delete';
+const NOTIFICATION_COPY_MANNSCHAFT = 'mannschaft_detail_copy';
 const NOTIFICATION_DELETE_MANNSCHAFT_SUCCESS = 'mannschaft_detail_delete_success';
 const NOTIFICATION_DELETE_MANNSCHAFT_FAILURE = 'mannschaft_detail_delete_failure';
 const NOTIFICATION_NO_LICENSE = 'no_license_found';
@@ -349,6 +350,41 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
                                     }
 
                                   });
+
+    this.notificationService.showNotification(notification);
+  }
+
+  public onCopyMannschaft(versionedDataObject: VersionedDataObject): void {
+
+    this.notificationService.discardNotification();
+
+    const id = versionedDataObject.id;
+    this.rows = showDeleteLoadingIndicatorIcon(this.rows, id);
+
+    const notification: Notification = {
+      id:               NOTIFICATION_COPY_MANNSCHAFT + id,
+      title:            'MANAGEMENT.MANNSCHAFT_DETAIL.NOTIFICATION.COPY.TITLE',
+      description:      'MANAGEMENT.MANNSCHAFT_DETAIL.NOTIFICATION.COPY.DESCRIPTION',
+      descriptionParam: '' + id,
+      severity:         NotificationSeverity.QUESTION,
+      origin:           NotificationOrigin.USER,
+      type:             NotificationType.YES_NO,
+      userAction:       NotificationUserAction.PENDING
+    };
+
+    const notificationEvent = this.notificationService.observeNotification(NOTIFICATION_COPY_MANNSCHAFT + id)
+      .subscribe((myNotification) => {
+
+        if (myNotification.userAction === NotificationUserAction.ACCEPTED) {
+          this.mannschaftsDataProvider.copyMannschaft(id)
+            .then((response) => this.loadMannschaften())
+            .catch((response) => this.rows = hideLoadingIndicator(this.rows, id));
+        } else if (myNotification.userAction === NotificationUserAction.DECLINED) {
+          this.rows = hideLoadingIndicator(this.rows, id);
+          notificationEvent.unsubscribe();
+        }
+
+      });
 
     this.notificationService.showNotification(notification);
   }

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.config.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.config.ts
@@ -30,10 +30,11 @@ export const VEREIN_DETAIL_TABLE_CONFIG: TableConfig = {
       },
     ],
     actions: {
-      actionTypes: [TableActionType.EDIT, TableActionType.DELETE, TableActionType.DOWNLOADLIZENZEN, TableActionType.DOWNLOADRUECKENNUMMER],
+      actionTypes: [TableActionType.EDIT, TableActionType.DELETE, TableActionType.DOWNLOADLIZENZEN, TableActionType.DOWNLOADRUECKENNUMMER, TableActionType.ADD],
       width:       6
     },
     deletePermission : [UserPermission.CAN_DELETE_STAMMDATEN],
-    editPermission: [UserPermission.CAN_MODIFY_MY_VEREIN, UserPermission.CAN_MODIFY_STAMMDATEN_LIGALEITER]
+    editPermission: [UserPermission.CAN_MODIFY_MY_VEREIN, UserPermission.CAN_MODIFY_STAMMDATEN_LIGALEITER],
+    addPermission: [UserPermission.CAN_MODIFY_MY_VEREIN, UserPermission.CAN_MODIFY_STAMMDATEN_LIGALEITER]
 
 };

--- a/bogenliga/src/app/modules/verwaltung/services/dsb-mannschaft-data-provider.service.ts
+++ b/bogenliga/src/app/modules/verwaltung/services/dsb-mannschaft-data-provider.service.ts
@@ -290,7 +290,7 @@ export class DsbMannschaftDataProviderService extends DataProviderService {
     // sign in failure -> reject promise with result
     return new Promise((resolve, reject) => {
       this.restClient.GET<VersionedDataTransferObject>(new UriBuilder().fromPath(this.getUrl()).
-      path('copymannschaftID/' + mannschaftID).build())
+      path('copyMannschaftID/' + mannschaftID).build())
         .then((data: VersionedDataTransferObject) => {
           resolve({result: RequestResult.SUCCESS});
 

--- a/bogenliga/src/app/modules/verwaltung/services/dsb-mannschaft-data-provider.service.ts
+++ b/bogenliga/src/app/modules/verwaltung/services/dsb-mannschaft-data-provider.service.ts
@@ -281,7 +281,30 @@ export class DsbMannschaftDataProviderService extends DataProviderService {
           });
     });
   }
-// Backend-Aufruf um eine Mannschaft eienr Veransatltung zuzuweisen.
+
+  // Gets executed when button "+" in Tabelle of Mannschaften is pressed
+  public copyMannschaft(mannschaftID: string | number): Promise<BogenligaResponse<void>> {
+
+    // return promise
+    // sign in success -> resolve promise
+    // sign in failure -> reject promise with result
+    return new Promise((resolve, reject) => {
+      this.restClient.GET<VersionedDataTransferObject>(new UriBuilder().fromPath(this.getUrl()).
+      path('copymannschaftID/' + mannschaftID).build())
+        .then((data: VersionedDataTransferObject) => {
+          resolve({result: RequestResult.SUCCESS});
+
+        }, (error: HttpErrorResponse) => {
+          if (error.status === 0) {
+            reject({result: RequestResult.CONNECTION_PROBLEM});
+          } else {
+            reject({result: RequestResult.FAILURE});
+          }
+        });
+    });
+  }
+
+  // Backend-Aufruf um eine Mannschaft eienr Veransatltung zuzuweisen.
   public assignMannschaftToVeranstaltung(currentVeranstaltungID: string | number, mannschaftID: string | number): Promise<BogenligaResponse<void>> {
 
     // return promise

--- a/bogenliga/src/assets/i18n/de.json
+++ b/bogenliga/src/assets/i18n/de.json
@@ -1162,6 +1162,10 @@
           "TITLE": "Mannschaft löschen",
           "DESCRIPTION": "Wollen Sie die Mannschaft wirklich löschen? Die Mannschaft ist danach nicht mehr verfügbar."
         },
+        "COPY": {
+          "TITLE": "Mannschaft kopieren",
+          "DESCRIPTION": "Wollen Sie die Mannschaft wirklich kopieren? Die Mannschaft wird  mit dem selben Namen und der selben Nummer erstellt."
+        },
         "DELETE_SUCCESS": {
           "TITLE": "Erfolg",
           "DESCRIPTION": "Mannschaft wurde erfolgreich gelöscht."

--- a/bogenliga/src/assets/i18n/en.json
+++ b/bogenliga/src/assets/i18n/en.json
@@ -1168,6 +1168,10 @@
             "TITLE": "Delete Team",
             "DESCRIPTION": "Are you sure, you want to delete the team? This can not be undone."
           },
+          "COPY": {
+            "TITLE": "Copy Team",
+            "DESCRIPTION": "Are you sure, you want to copy the team? This will create a new team with the same name and members."
+          },
           "DELETE_SUCCESS": {
             "TITLE": "Success",
             "DESCRIPTION": "Successfully deleted team."


### PR DESCRIPTION
Umsetzung der Stories
Kopieren von Mannschaften https://gitlab.gras-it.de/hsrt/swt2/-/issues/1939
Anlegen von Mannschaften ohne Liga-Zuordnung https://gitlab.gras-it.de/hsrt/swt2/-/issues/1938