### PR TITLE
Add LeagueHierarchyService with API contract and unit tests

### DIFF
--- a/bogenliga/docs/api/league-hierarchy.md
+++ b/bogenliga/docs/api/league-hierarchy.md
@@ -1,0 +1,55 @@
+# Liga-Hierarchie API-Contract
+
+Ziel: Konsistenter, klar typisierter Zugriff auf Liga-Hierarchiedaten.
+
+Basis-URL
+- Aus Environment: `environment.backendBaseUrl`
+  - Dev: `http://localhost:9000`
+  - Prod: `https://liga.bsapp.de/api`
+
+Endpoints (v1)
+- GET `/v1/liga`
+  - Beschreibung: Liefert eine flache Liste aller Ligen. Die Hierarchie wird über `ligaUebergeordnetId` rekonstruiert (null = Root).
+  - Auth: JWT (global registrierter JwtInterceptor)
+  - Response 200 (application/json):
+    - Array von Objekten mit Feldern (vereinfachtes Schema):
+      - `id: number`
+      - `name: string`
+      - `ligaUebergeordnetId?: number | null`
+      - `regionId?: number | null`
+      - `version?: number`
+  - Response 4xx/5xx: Fehlerobjekt; UI bekommt Status-Mapping durch Service (siehe unten).
+
+- GET `/v1/liga/{id}`
+  - Beschreibung: Detail einer Liga (für Drill-Down oder Lazy-Loading einzelner Pfade).
+
+- GET `/v1/liga/lowest/{id}`
+  - Beschreibung: Liefert die unterste Liga im Pfad (Validierung/Leaf-Ermittlung).
+
+Versionierung
+- Pfad-basiert (`/v1/...`). Weitere Versionen werden über neue Pfade eingeführt.
+
+Caching
+- Serverseitig empfohlene Header (optional): `Cache-Control`, `ETag`.
+- Clientseitig: Der LeagueHierarchyService liest keine ETags, kann aber problemlos erweitert werden.
+
+Service-Verhalten (LeagueHierarchyService)
+- Quelle: `GET /v1/liga`
+- Timeout: 6000 ms (konfigurierbar über Options)
+- Fehlerbehandlung: HTTP-Fehler und Timeouts werden gemappt.
+- Fallback: Lokale Mockdaten `assets/mocks/league-hierarchy.json` werden bei Fehlern geladen.
+- Status-Mapping (UI-freundlich):
+  - `ok`: Erfolgreich, Daten vorhanden
+  - `empty`: 200 aber leere Liste
+  - `timeout`: Zeitüberschreitung
+  - `error`: HTTP-Fehler (4xx/5xx)
+  - `offline-fallback`: Mockdaten wurden genutzt
+
+Response-Typen (Frontend)
+- API-DTO: `LeagueDTO` (`src/app/modules/shared/models/league.dto.ts`)
+- UI-Baum: `LeagueTreeNode` (`src/app/modules/shared/models/tree-node.ts`)
+- Ergebnis: `LeagueHierarchyResult` (Status + Baum)
+
+Mockdaten
+- Datei: `src/assets/mocks/league-hierarchy.json`
+- Format: Flache Liste im `LeagueDTO`-Format; der Service baut daraus den Baum.

--- a/bogenliga/src/app/modules/shared/models/league.dto.ts
+++ b/bogenliga/src/app/modules/shared/models/league.dto.ts
@@ -1,0 +1,12 @@
+// Data Transfer Object (DTO) for the League API (v1/liga)
+// Mirrors the backend response as a flat list with optional parent references.
+
+export interface LeagueDTO {
+  id: number;
+  name: string;
+  regionId?: number | null;
+  disziplinId?: number | null;
+  ligaUebergeordnetId?: number | null; // parent league id (null for root)
+  ligaUebergeordnetName?: string | null;
+  version?: number | null;
+}

--- a/bogenliga/src/app/modules/shared/models/tree-node.ts
+++ b/bogenliga/src/app/modules/shared/models/tree-node.ts
@@ -1,0 +1,17 @@
+// UI tree node type for representing the league hierarchy in components
+
+export interface LeagueTreeNode {
+  id: number;
+  name: string;
+  parentId?: number | null;
+  level: number; // 0-based depth level (0 for root)
+  children: LeagueTreeNode[];
+}
+
+export interface LeagueHierarchyResult {
+  // High-level status to simplify UI consumption
+  status: 'ok' | 'empty' | 'error' | 'timeout' | 'offline-fallback';
+  httpStatus?: number;
+  reason?: string;
+  data: LeagueTreeNode[];
+}

--- a/bogenliga/src/app/modules/shared/services/index.ts
+++ b/bogenliga/src/app/modules/shared/services/index.ts
@@ -3,3 +3,4 @@ export * from './error-handling';
 export * from './notification';
 export * from './onoffline';
 export * from './recent-liga';
+export * from './league-hierarchy/league-hierarchy.service';

--- a/bogenliga/src/app/modules/shared/services/league-hierarchy/league-hierarchy.service.spec.ts
+++ b/bogenliga/src/app/modules/shared/services/league-hierarchy/league-hierarchy.service.spec.ts
@@ -1,0 +1,102 @@
+import {TestBed, fakeAsync, tick} from '@angular/core/testing';
+import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
+import {LeagueHierarchyService} from './league-hierarchy.service';
+import {environment} from '@environment';
+import {LeagueDTO} from '@shared/models/league.dto';
+
+describe('LeagueHierarchyService', () => {
+  let service: LeagueHierarchyService;
+  let httpMock: HttpTestingController;
+
+  const apiUrl = `${environment.backendBaseUrl}/v1/liga`;
+  const mockFlat: LeagueDTO[] = [
+    { id: 1, name: 'Bundesliga', ligaUebergeordnetId: null },
+    { id: 2, name: 'Regionalliga', ligaUebergeordnetId: 1 },
+  ];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [LeagueHierarchyService]
+    });
+    service = TestBed.inject(LeagueHierarchyService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should build a tree from flat list (200)', () => {
+    service.getHierarchy().subscribe((res) => {
+      expect(res.status).toBe('ok');
+      expect(res.data.length).toBe(1); // one root
+      expect(res.data[0].children.length).toBe(1);
+    });
+
+    const req = httpMock.expectOne(apiUrl);
+    expect(req.request.method).toBe('GET');
+    req.flush(mockFlat);
+  });
+
+  it('should map empty response to status "empty"', () => {
+    service.getHierarchy().subscribe((res) => {
+      expect(res.status).toBe('empty');
+      expect(res.data.length).toBe(0);
+    });
+
+    const req = httpMock.expectOne(apiUrl);
+    req.flush([]);
+  });
+
+  it('should fallback to local mock on 404', () => {
+    service.getHierarchy().subscribe((res) => {
+      expect(res.status).toBe('offline-fallback');
+      expect(res.data.length).toBeGreaterThan(0);
+    });
+
+    const req = httpMock.expectOne(apiUrl);
+    req.flush({}, { status: 404, statusText: 'Not Found' });
+
+    const mockReq = httpMock.expectOne('./assets/mocks/league-hierarchy.json');
+    mockReq.flush([
+      { id: 1, name: 'Bundesliga', ligaUebergeordnetId: null },
+      { id: 2, name: 'Regionalliga', ligaUebergeordnetId: 1 }
+    ]);
+  });
+
+  it('should map timeout to status "timeout" and still try fallback', fakeAsync(() => {
+    let finalStatus: string | undefined;
+
+    service.getHierarchy({ timeoutMs: 10 }).subscribe((res) => {
+      finalStatus = res.status;
+      // if fallback kicks in, status will be offline-fallback
+      // otherwise timeout
+    });
+
+    const req = httpMock.expectOne(apiUrl);
+    // do not flush -> simulate timeout
+    tick(11);
+
+    const mockReq = httpMock.expectOne('./assets/mocks/league-hierarchy.json');
+    mockReq.flush([
+      { id: 1, name: 'Bundesliga', ligaUebergeordnetId: null }
+    ]);
+
+    expect(finalStatus).toBe('offline-fallback');
+  }));
+
+  it('should map 500 to status error and still try fallback', () => {
+    service.getHierarchy().subscribe((res) => {
+      expect(['offline-fallback', 'error']).toContain(res.status);
+    });
+
+    const req = httpMock.expectOne(apiUrl);
+    req.flush({}, { status: 500, statusText: 'Server Error' });
+
+    const mockReq = httpMock.expectOne('./assets/mocks/league-hierarchy.json');
+    mockReq.flush([
+      { id: 1, name: 'Bundesliga', ligaUebergeordnetId: null }
+    ]);
+  });
+});

--- a/bogenliga/src/app/modules/shared/services/league-hierarchy/league-hierarchy.service.ts
+++ b/bogenliga/src/app/modules/shared/services/league-hierarchy/league-hierarchy.service.ts
@@ -1,0 +1,105 @@
+import {Injectable} from '@angular/core';
+import {HttpClient, HttpErrorResponse} from '@angular/common/http';
+import {environment} from '@environment';
+import {UriBuilder} from '@shared/data-provider/services/utils/uri-builder.class';
+import {LeagueDTO} from '@shared/models/league.dto';
+import {LeagueHierarchyResult, LeagueTreeNode} from '@shared/models/tree-node';
+import {Observable, of, throwError} from 'rxjs';
+import {catchError, map, timeout, switchMap} from 'rxjs/operators';
+
+// Default timeout for API calls (ms)
+const DEFAULT_TIMEOUT_MS = 6000;
+// Local mock path for fallback
+const MOCK_FLAT_LIST_URL = './assets/mocks/league-hierarchy.json';
+
+@Injectable({ providedIn: 'root' })
+export class LeagueHierarchyService {
+  private readonly baseUrl = environment.backendBaseUrl;
+  private readonly ligaPath = 'v1/liga';
+
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Loads league hierarchy as a tree. Builds the tree client-side from the flat league list.
+   * Robust handling: timeout, HTTP error mapping, and local mock fallback.
+   */
+  getHierarchy(options?: { timeoutMs?: number }): Observable<LeagueHierarchyResult> {
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const url = new UriBuilder().fromPath(this.baseUrl).path(this.ligaPath).build();
+
+    return this.http.get<LeagueDTO[]>(url).pipe(
+      timeout(timeoutMs),
+      map((list) => this.fromFlatList(list)),
+      map((nodes) => nodes.length === 0
+        ? ({ status: 'empty', data: nodes } as LeagueHierarchyResult)
+        : ({ status: 'ok', data: nodes } as LeagueHierarchyResult)
+      ),
+      catchError((err: HttpErrorResponse | any) => this.handleErrorThenFallback(err))
+    );
+  }
+
+  /**
+   * Try to recover by serving local mock data if available; otherwise emit mapped error.
+   */
+  private handleErrorThenFallback(err: HttpErrorResponse | any): Observable<LeagueHierarchyResult> {
+    const mapped = this.mapError(err);
+    // Attempt local mock fallback
+    return this.http.get<LeagueDTO[]>(MOCK_FLAT_LIST_URL).pipe(
+      map((list) => this.fromFlatList(list)),
+      map((nodes) => ({ status: 'offline-fallback', data: nodes } as LeagueHierarchyResult)),
+      catchError(() => of(mapped))
+    );
+  }
+
+  private mapError(err: HttpErrorResponse | any): LeagueHierarchyResult {
+    if (err?.name === 'TimeoutError') {
+      return { status: 'timeout', data: [], reason: 'Request timed out' };
+    }
+    if (err instanceof HttpErrorResponse) {
+      return { status: 'error', data: [], httpStatus: err.status, reason: err.message };
+    }
+    return { status: 'error', data: [], reason: 'Unknown error' };
+  }
+
+  /**
+   * Build a hierarchical tree from flat league list using ligaUebergeordnetId as parent reference.
+   */
+  private fromFlatList(list: LeagueDTO[]): LeagueTreeNode[] {
+    if (!Array.isArray(list) || list.length === 0) { return []; }
+
+    const byId = new Map<number, LeagueTreeNode>();
+    const roots: LeagueTreeNode[] = [];
+
+    // Create nodes
+    for (const item of list) {
+      const node: LeagueTreeNode = {
+        id: item.id,
+        name: item.name,
+        parentId: item.ligaUebergeordnetId ?? null,
+        level: 0,
+        children: []
+      };
+      byId.set(item.id, node);
+    }
+
+    // Link children and collect roots
+    for (const item of list) {
+      const node = byId.get(item.id)!;
+      const parentId = item.ligaUebergeordnetId ?? null;
+      if (parentId == null) {
+        roots.push(node);
+      } else {
+        const parent = byId.get(parentId);
+        if (parent) {
+          node.level = parent.level + 1;
+          parent.children.push(node);
+        } else {
+          // Orphan node without existing parent -> treat as root
+          roots.push(node);
+        }
+      }
+    }
+
+    return roots;
+  }
+}

--- a/bogenliga/src/assets/mocks/league-hierarchy.json
+++ b/bogenliga/src/assets/mocks/league-hierarchy.json
@@ -1,0 +1,8 @@
+[
+  { "id": 1, "name": "Bundesliga", "ligaUebergeordnetId": null },
+  { "id": 2, "name": "Regionalliga Nord", "ligaUebergeordnetId": 1 },
+  { "id": 3, "name": "Regionalliga Süd", "ligaUebergeordnetId": 1 },
+  { "id": 4, "name": "Oberliga Hamburg", "ligaUebergeordnetId": 2 },
+  { "id": 5, "name": "Oberliga Bremen", "ligaUebergeordnetId": 2 },
+  { "id": 6, "name": "Verbandsliga München", "ligaUebergeordnetId": 3 }
+]

--- a/changelogs/README.md
+++ b/changelogs/README.md
@@ -18,4 +18,5 @@ Die Changelogs folgen dem [Keep a Changelog](https://keepachangelog.com/de/1.0.0
 ## Aktuelle Changelogs
 
 - `changelog-2025-11-01-ligauebersicht.md` - Ligaübersicht Modul (Issue #1957-Frontend)
+- `changelog-2025-11-09-league-hierarchy-service.md` - Liga-Hierarchie Service
 

--- a/changelogs/changelog-2025-11-09-league-hierarchy-service.md
+++ b/changelogs/changelog-2025-11-09-league-hierarchy-service.md
@@ -1,0 +1,37 @@
+# Changelog
+
+Alle bemerkenswerten Änderungen an diesem Projekt werden in dieser Datei dokumentiert.
+
+Das Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/),
+und dieses Projekt hält sich an [Semantic Versioning](https://semver.org/lang/de/).
+
+## [Unreleased]
+
+## [2025-11-09] - Liga-Hierarchie Service
+
+### Hinzugefügt
+- API-Contract-Dokumentation für Liga-Hierarchie
+  - `bogenliga/docs/api/league-hierarchy.md`
+- Neuer `LeagueHierarchyService` mit Timeout, Fehler-/Leerdatenbehandlung, Status-Mapping und lokalem Mock-Fallback
+  - `bogenliga/src/app/modules/shared/services/league-hierarchy/league-hierarchy.service.ts`
+  - Export über Barrel: `bogenliga/src/app/modules/shared/services/index.ts`
+- Streng typisierte Modelle/DTOs
+  - `bogenliga/src/app/modules/shared/models/league.dto.ts`
+  - `bogenliga/src/app/modules/shared/models/tree-node.ts`
+- Lokale Mockdaten als Fallback
+  - `bogenliga/src/assets/mocks/league-hierarchy.json`
+- Unit-Tests (HttpClientTestingModule) inkl. 200/404/500/Timeout/Empty
+  - `bogenliga/src/app/modules/shared/services/league-hierarchy/league-hierarchy.service.spec.ts`
+
+### Geändert
+- Export in `shared/services/index.ts` um `LeagueHierarchyService` ergänzt
+
+### Technische Details
+- Dateien geändert/neu:
+  - Neu: `bogenliga/src/app/modules/shared/models/league.dto.ts`
+  - Neu: `bogenliga/src/app/modules/shared/models/tree-node.ts`
+  - Neu: `bogenliga/src/app/modules/shared/services/league-hierarchy/league-hierarchy.service.ts`
+  - Neu: `bogenliga/src/app/modules/shared/services/league-hierarchy/league-hierarchy.service.spec.ts`
+  - Neu: `bogenliga/src/assets/mocks/league-hierarchy.json`
+  - Neu: `bogenliga/docs/api/league-hierarchy.md`
+  - Geändert: `bogenliga/src/app/modules/shared/services/index.ts`


### PR DESCRIPTION
(https://gitlab.gras-it.de/hsrt/swt2/-/issues/1958)

This pull request introduces a new, robust league hierarchy service to the project, providing a clear API contract, strict typing, error handling, and fallback mechanisms for accessing league hierarchy data. The implementation includes both backend documentation and frontend services, as well as comprehensive unit tests and local mock data for offline scenarios.

**League Hierarchy Service Implementation:**

- Added `LeagueHierarchyService` with features such as configurable timeout, error/status mapping, and automatic fallback to local mock data in case of backend errors or timeouts. The service builds a tree structure from a flat league list and returns a status-rich result for easy UI consumption.
- Exported the new service via the shared services barrel file for easy importing elsewhere in the app.

**API Contract & Data Models:**

- Documented the API contract for league hierarchy endpoints, including expected responses, authentication, versioning, and error handling, in `league-hierarchy.md`.
- Introduced strict TypeScript models for both the backend DTO (`LeagueDTO`) and the frontend tree node (`LeagueTreeNode`), as well as a result wrapper (`LeagueHierarchyResult`) for status handling. [[1]](diffhunk://#diff-8dbf4b8451737a311db27b70a650c371641ab595c43b93754e71edc19544deb7R1-R12) [[2]](diffhunk://#diff-66144aa857efe3827ff45884e1c8c80d80117dfa770ed84ca2a0df29aba79df8R1-R17)

**Testing & Mock Data:**

- Created comprehensive unit tests for the new service, covering success, empty, error, timeout, and mock fallback scenarios using Angular's `HttpClientTestingModule`.
- Provided local mock data (`league-hierarchy.json`) to be used as a fallback when the backend is unavailable.

**Documentation & Changelog:**

- Added a changelog entry summarizing these additions and changes for future reference. [[1]](diffhunk://#diff-9ee0af1adde6661e290490c87ca0e6d0c352d7654951eadf0a3c4f0f2eb5ab68R1-R37) [[2]](diffhunk://#diff-0cc21d32bf36d13d427fe25782365736f3357740e2506770de9bd2ba18e7bffdR21)