### PR TITLE
Wettkampfdurchführung separieren

### DIFF
--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/index.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/index.ts
@@ -4,4 +4,4 @@ export * from './schusszettel/number.directive';
 export {RingzahlTabIndexDirective, SchuetzenTabIndexDirective} from './schusszettel/tabindex.directive';
 export * from './tablet-admin/tablet-admin.component';
 export * from './tableteingabe/tableteingabe.component';
-export * from './fullscreen/fullscreen.component'
+export * from './fullscreen/fullscreen.component';

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.html
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.html
@@ -174,7 +174,7 @@
               [id]="'wettkampfDurchfuehrung'"
               [color]="ActionButtonColors.PRIMARY"
               [iconClass]="'arrow-right'"
-              (onClick)="toggleDiv()"
+              (onClick)="openSecondView()"
               [disabled]="isDisabled()">
               {{ 'WKDURCHFUEHRUNG.BUTTON.DURCHFUEHRUNG' | translate }}
             </bla-actionbutton>
@@ -243,7 +243,7 @@
           [id]="'zurück'"
           [color]="ActionButtonColors.PRIMARY"
           [iconClass]="'arrow-left'"
-          (onClick)="toggleDiv()">
+          (onClick)="openSecondView()">
           {{ 'WKDURCHFUEHRUNG.BUTTON.ZURUECK' | translate }}
         </bla-actionbutton>
       </div>

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.html
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.html
@@ -243,7 +243,7 @@
           [id]="'zurück'"
           [color]="ActionButtonColors.PRIMARY"
           [iconClass]="'arrow-left'"
-          (onClick)="openSecondView()">
+          (onClick)="goBack()">
           {{ 'WKDURCHFUEHRUNG.BUTTON.ZURUECK' | translate }}
         </bla-actionbutton>
       </div>

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.ts
@@ -510,7 +510,7 @@ export class WkdurchfuehrungComponent extends CommonComponentDirective implement
       this.loadTableRows();
     }
   }
-  // when a Wettkmapftag gets selected from the list --> ID for Buttons
+  // when a Wettkampftag gets selected from the list --> ID for Buttons
   public onView($event: VersionedDataObject): void {
     // Überprüft, ob ein gültiger Wettkampf ausgewählt wurde
     if ($event.id >= 0) {

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.ts
@@ -667,16 +667,13 @@ export class WkdurchfuehrungComponent extends CommonComponentDirective implement
       this.matchProvider.pair(this.selectedMatchId)
           .then((data) => {
             if (data.payload.length === 2) {
-// das wÃ¤re schÃ¶ner - funktioniert leider aber noch nicht...
-// Ã¶ffne die Datenerfassung in einem neuen Tab
-              /*            this.urlString = new UriBuilder()
-               .fromPath(environment.)
-               .path('/#/schusszettel/'+ data.payload[0])
-               .path('/' + data.payload[1])
-               .build();
-               window.open(this.urlString, '_blank')
-               */
-              this.router.navigate(['/wkdurchfuehrung/schusszettel/' + data.payload[0] + '/' + data.payload[1]]);
+              const url = '#' + this.router.serializeUrl(
+                this.router.createUrlTree(
+                  [new UriBuilder().path('/wkdurchfuehrung/schusszettel/' + data.payload[0] + '/' + data.payload[1]).build() ]
+                )
+              );
+              window.open(url, '_blank');
+//              this.router.navigate(['/wkdurchfuehrung/schusszettel/' + data.payload[0] + '/' + data.payload[1]]);
             }
           });
     }

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.ts
@@ -132,7 +132,6 @@ export class WkdurchfuehrungComponent extends CommonComponentDirective implement
     // statt einfach nur einen Teil ein/auszublenden - rufen wir hier jetzt den ganzen Dialog nochmal auf
     // wir setzen beim AUfruf in den Pfad die Wettkampf-ID ein - damit kann man später vom Schusszettel auf die Matchliste zurückspringen
 
-    console.log('selectedWettkampftag wkdurchführung', this.selectedVeranstaltungId, this.selectedWettkampf);
     const url = '#' + this.router.serializeUrl(
       this.router.createUrlTree(
         [new UriBuilder().path('wkdurchfuehrung/' + this.selectedVeranstaltungId + '/' + this.selectedWettkampf).build() ]

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.ts
@@ -134,7 +134,7 @@ export class WkdurchfuehrungComponent extends CommonComponentDirective implement
 
   openSecondView() {
     // statt einfach nur einen Teil ein/auszublenden - rufen wir hier jetzt den ganzen Dialog nochmal auf
-    // wir setzen beim AUfruf in den Pfad die Wettkampf-ID ein - damit kann man später vom Schusszettel auf die Matchliste zurückspringen
+    // wir setzen beim Aufruf in den Pfad die Wettkampf-ID ein - damit kann man später vom Schusszettel auf die Matchliste zurückspringen
 
     const url = '#' + this.router.serializeUrl(
       this.router.createUrlTree(

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.ts
@@ -672,7 +672,6 @@ export class WkdurchfuehrungComponent extends CommonComponentDirective implement
                 )
               );
               window.open(url, '_blank');
-//              this.router.navigate(['/wkdurchfuehrung/schusszettel/' + data.payload[0] + '/' + data.payload[1]]);
             }
           });
     }

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.ts
@@ -128,6 +128,10 @@ export class WkdurchfuehrungComponent extends CommonComponentDirective implement
   // Definiert das Array groupedMatches mit der Struktur { groupName: string; matches: TableRow[] }
   groupedMatches: { groupName: string; matches: TableRow[] }[] = [];
 
+  goBack(): void {
+    window.history.back();
+  }
+
   openSecondView() {
     // statt einfach nur einen Teil ein/auszublenden - rufen wir hier jetzt den ganzen Dialog nochmal auf
     // wir setzen beim AUfruf in den Pfad die Wettkampf-ID ein - damit kann man später vom Schusszettel auf die Matchliste zurückspringen

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.ts
@@ -51,8 +51,8 @@ import {ActionButtonColors} from '@shared/components/buttons/button/actionbutton
 
 export class WkdurchfuehrungComponent extends CommonComponentDirective implements OnInit {
 
-  public div1Visible: boolean = false;
-  public div2Visible: boolean = true;
+  public div1Visible = false;
+  public div2Visible = true;
   public ActionButtonColors = ActionButtonColors;
   public config = WKDURCHFUEHRUNG_CONFIG;
   public config_table = WETTKAMPF_TABLE_CONFIG;
@@ -77,13 +77,14 @@ export class WkdurchfuehrungComponent extends CommonComponentDirective implement
   private remainingWettkampfRequests: number;
   private remainingMatchRequests: number;
   public currentVeranstaltungName;
+  private veranstaltungId;
   private wettkampfId;
   private disableGMButton = true;
   private disabledOtherButtons = true;
   wettkampfIdEnthalten: boolean;
   public wettkampfListe;
   private aktivesSportjahr: number;
-  wettkampf : WettkampfDO;
+  wettkampf: WettkampfDO;
   wettkaempfe: Array<WettkampfDO> = [new WettkampfDO()];
   veranstaltung: VeranstaltungDO;
   public matches: Array<MatchDO[]> = [];
@@ -101,37 +102,55 @@ export class WkdurchfuehrungComponent extends CommonComponentDirective implement
 
   private sessionHandling: SessionHandling;
 
+
   constructor(private router: Router,
-    private route: ActivatedRoute,
-    private notificationService: NotificationService,
-    private veranstaltungsDataProvider: VeranstaltungDataProviderService,
-    private einstellungenDataProvider: EinstellungenProviderService,
-    private wettkampfDataProvider: WettkampfDataProviderService,
-    private matchDataProvider: MatchDataProviderService,
-    private passeDataProviderService: PasseDataProviderService,
-    private matchProvider: MatchProviderService,
-    private onOfflineService: OnOfflineService,
-    private currentUserService: CurrentUserService,
-    private wettkampfOfflineSyncService: WettkampfOfflineSyncService,
-    private dialog: MatDialog,
-    private dsbMannschaftDataProviderService: DsbMannschaftDataProviderService
+              private route: ActivatedRoute,
+              private notificationService: NotificationService,
+              private veranstaltungsDataProvider: VeranstaltungDataProviderService,
+              private einstellungenDataProvider: EinstellungenProviderService,
+              private wettkampfDataProvider: WettkampfDataProviderService,
+              private matchDataProvider: MatchDataProviderService,
+              private passeDataProviderService: PasseDataProviderService,
+              private matchProvider: MatchProviderService,
+              private onOfflineService: OnOfflineService,
+              private currentUserService: CurrentUserService,
+              private wettkampfOfflineSyncService: WettkampfOfflineSyncService,
+              private dialog: MatDialog,
+              private dsbMannschaftDataProviderService: DsbMannschaftDataProviderService
 
   ) {
     super();
     this.sessionHandling = new SessionHandling(this.currentUserService, this.onOfflineService);
   }
-  toggleDiv(){
-    //Setzt die Sichtbarkeit der divs und simuliert damit eine neue Seite
-    this.div1Visible = !this.div1Visible;
-    this.div2Visible = !this.div2Visible;
+
+
+
+  // Definiert das Array groupedMatches mit der Struktur { groupName: string; matches: TableRow[] }
+  groupedMatches: { groupName: string; matches: TableRow[] }[] = [];
+
+  openSecondView() {
+    // statt einfach nur einen Teil ein/auszublenden - rufen wir hier jetzt den ganzen Dialog nochmal auf
+    // wir setzen beim AUfruf in den Pfad die Wettkampf-ID ein - damit kann man später vom Schusszettel auf die Matchliste zurückspringen
+
+    console.log('selectedWettkampftag wkdurchführung', this.selectedVeranstaltungId, this.selectedWettkampf);
+    const url = '#' + this.router.serializeUrl(
+      this.router.createUrlTree(
+        [new UriBuilder().path('wkdurchfuehrung/' + this.selectedVeranstaltungId + '/' + this.selectedWettkampf).build() ]
+      )
+    );
+    window.open(url, '_blank');
   }
+
   ngOnInit() {
 
     this.route.params.subscribe((params) => {
 
       if (!isUndefined(params['wettkampfId'])) {
         // WettkampfId im Pfad enthalten -> Wettkampf soll automatisch ausgewaehlt werden
+
+
         this.wettkampfIdEnthalten = true;
+        this.veranstaltungId = parseInt(params['veranstaltungId'], 10);
         this.wettkampfId = parseInt(params['wettkampfId'], 10);
         console.log('WettkampfID:', this.wettkampfId);
 
@@ -149,8 +168,13 @@ export class WkdurchfuehrungComponent extends CommonComponentDirective implement
 
 
 
-        this.findAvailableYears();
-        this.visible = false;
+        this.selectedVeranstaltungId = this.veranstaltungId;
+        this.selectedWettkampfId = this.wettkampfId;
+        this.showMatches();
+        this.visible = true;
+        // Setzt die Sichtbarkeit der divs und simuliert damit eine neue Seite
+        this.div1Visible = true; // ausblenden
+        this.div2Visible = false; // sichtbar
 
       } else if (this.onOfflineService.isOffline()) {
         // falls offline, Veranstaltung aus id die im onOfflineService gespeichert ist laden
@@ -487,7 +511,7 @@ export class WkdurchfuehrungComponent extends CommonComponentDirective implement
       this.loadTableRows();
     }
   }
-  // when a Ligatabelle gets selected from the list --> ID for Buttons
+  // when a Wettkmapftag gets selected from the list --> ID for Buttons
   public onView($event: VersionedDataObject): void {
     // Überprüft, ob ein gültiger Wettkampf ausgewählt wurde
     if ($event.id >= 0) {
@@ -593,7 +617,7 @@ export class WkdurchfuehrungComponent extends CommonComponentDirective implement
     return this.onOfflineService.isOffline();
   }
   public isDisabledGMButton(): boolean {
-    return this.disableGMButton; //prüft ob der disableGMButton-Wert auf true gesetzt ist & ob ein Wettkampf ausgwählt wurde
+    return this.disableGMButton; // prüft ob der disableGMButton-Wert auf true gesetzt ist & ob ein Wettkampf ausgwählt wurde
   }
   public generateMatches() {
     // Generiert Daten für die Matches basierend auf der ausgewählten Wettkampf-ID
@@ -703,11 +727,6 @@ export class WkdurchfuehrungComponent extends CommonComponentDirective implement
     this.matchRows = [];
     this.loadingMatch = false;
   }
-
-
-
-  // Definiert das Array groupedMatches mit der Struktur { groupName: string; matches: TableRow[] }
-  groupedMatches: { groupName: string; matches: TableRow[] }[] = [];
   // Gruppiere die Matches basierend auf der Nummer (nr)
   groupMatches(matches: MatchDOExt[]) {
     const groupedMatchesMap = new Map<number, MatchDOExt[]>();
@@ -734,7 +753,7 @@ export class WkdurchfuehrungComponent extends CommonComponentDirective implement
       this.loadingMatch = false;
     }
     // Konvertiert die MatchDTOExt-Objekte in MatchDOExt-Objekte und speichere sie im tableContentMatch-Array
-    this.tableContentMatch = response.payload.map(match => {
+    this.tableContentMatch = response.payload.map((match) => {
       const tableContentRow: MatchDOExt = new MatchDOExt();
       tableContentRow.id = match.id;
       tableContentRow.matchNr = match.matchNr;

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.config.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.config.ts
@@ -46,8 +46,6 @@ export const WETTKAMPF_TABLE_CONFIG: TableConfig = {
   coloredActionsWithText: true
   };
 
-
-
 export const MATCH_TABLE_CONFIG: TableConfig = {
 
   columns: [
@@ -85,4 +83,7 @@ export const MATCH_TABLE_CONFIG: TableConfig = {
   }
 
 };
+
+
+
 

--- a/bogenliga/src/app/modules/wkdurchfuehrung/wkdurchfuehrung.module.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/wkdurchfuehrung.module.ts
@@ -53,7 +53,7 @@ import {QRCodeModule} from 'angularx-qrcode';
     WkdurchfuehrungGuard,
     SchusszettelGuard,
     TableteingabeGuard,
-    TabletadminGuard
+    TabletadminGuard,
   ],
   exports: [
     SchusszettelComponent

--- a/bogenliga/src/app/modules/wkdurchfuehrung/wkdurchfuehrung.routing.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/wkdurchfuehrung.routing.ts
@@ -19,7 +19,7 @@ export const wkdurchfuehrung_ROUTES: Routes = [
   {path: '', pathMatch: 'full', component: TabletAdminComponent},
   {path: '', pathMatch: 'full', component: TabletAdminPopUpComponent},
   {path: 'fullscreen', pathMatch: 'full', component: FullscreenComponent},
-  {path: ':wettkampfId', pathMatch: 'full', component: WkdurchfuehrungComponent},
+  {path: ':veranstaltungId/:wettkampfId', pathMatch: 'full', component: WkdurchfuehrungComponent},
   {path: 'tabletadmin/:wettkampfId', pathMatch: 'full', component: TabletAdminComponent},
   {path: 'schusszettel/:match1id/:match2id', pathMatch: 'full', component: SchusszettelComponent},
   {path: ':match1id/:match2id/tablet', pathMatch: 'full', component: TabletEingabeComponent},


### PR DESCRIPTION
Zerteilen des Dialogs Wettkampfdurchführung - die beiden Modus werden jetzt in separaten Tabs geöffnet.
1) Öffnen Wettkampfdurchführung in der Seitenleiste auswählen, Veranstaltung wählen, Wettkampftag wählen
2) Bei Auswahl des Button "Wettkampf Durchführung" wird jetzt ein neuer Tab geöffnet und in diesem die Liste der Mannschaften und die Liste der Matches dargestellt
3) Bei Auswahl des "Edit-Buttons" an einem Match wird der Schusszettel in einem neuen Tab geöffnet

