### PR TITLE
Remove old ligatabelle navigation and update routing to new liga over…

### DIFF
--- a/bogenliga/docs/TICKET_ENTFERNUNG_ALTE_LIGATABELLE.md
+++ b/bogenliga/docs/TICKET_ENTFERNUNG_ALTE_LIGATABELLE.md
@@ -1,0 +1,28 @@
+# Ticket-Dokumentation: Entfernung der alten Ligatabellen-Navigation
+
+## Kontext
+- Ziel: Alle direkten Navigationspfade zur alten Ligatabelle (`/ligatabelle`, `/ligatabelle/:id`) deaktivieren, damit ausschließlich die neue Ligaübersicht (`/liga`) verwendet wird.
+- Hintergrund: Vorbereitung für EPIC 4 (vollständiger Rückbau des Ligatabelle-Moduls).
+- Referenz: `bogenliga/ENTFERNUNG_ALTE_LIGATABELLE.md` (Detail-Dokumentation im Projektstamm).
+
+## Umgesetzte Änderungen
+- Routing (`src/app/app.routing.ts`): Einträge für `/ligatabelle` entfernt.
+- Sidebar (`src/app/components/sidebar/sidebar.config.ts` & `.component.ts`): Menüpunkt „Mannschaften“ und Ligatabelle-spezifische URL-Logik entfernt.
+- Regionenmodul (`src/app/modules/regionen/components/regionen/regionen.component.ts`): Ligaauswahl navigiert nun zu `/liga`.
+- Projektdokumentation & Changelog: Aktualisierte Statusübersicht und neuer Eintrag `changelogs/changelog-2025-11-10-entfernung-ligatabelle-navigation.md`.
+
+## Auswirkungen für Benutzer:innen
+- Sidebar zeigt keinen Link mehr zur alten Ligatabelle.
+- Direkte Aufrufe von `/ligatabelle` resultieren in 404; stattdessen führt die Navigation zur neuen Ligaübersicht.
+- Regionenansicht leitet nach Ligaauswahl sofort zur Ligaübersicht.
+
+## Test- und Rollout-Hinweise
+- Browser-Test: Sidebar öffnen, Liga über Regionen auswählen → Weiterleitung nach `/liga`.
+- Direkte URL-Tests: `/ligatabelle` bzw. `/ligatabelle/:id` aufrufen → erwarteter 404.
+- Empfohlen: `npm run lint` sowie e2e-/Manualtests in CI, sobald verfügbar.
+
+## Offene Punkte / Folgearbeiten
+- i18n-Einträge und Restbestand des Ligatabelle-Moduls werden im Rahmen von EPIC 4 bereinigt.
+- Analytics-Tracking für `/liga` bleibt aktiv; Monitoring der Zugriffszahlen prüfen.
+
+

--- a/bogenliga/src/app/app.routing.ts
+++ b/bogenliga/src/app/app.routing.ts
@@ -18,8 +18,6 @@ export const ROUTES: Routes = [
   {path: 'vereine', loadChildren: () => import('src/app/modules/vereine/vereine.module').then((m) => m.VereineModule)},
   {path: 'vereine/:id', loadChildren: () => import('src/app/modules/vereine/vereine.module').then((m) => m.VereineModule)},
   {path: 'playground', loadChildren: () => import('src/app/modules/playground/playground.module').then((m) => m.PlaygroundModule)},
-  {path: 'ligatabelle', loadChildren: () => import('src/app/modules/ligatabelle/ligatabelle.module').then((m) => m.LigatabelleModule)},
-  {path: 'ligatabelle/:id', loadChildren: () => import('src/app/modules/ligatabelle/ligatabelle.module').then((m) => m.LigatabelleModule)},
   {path: 'liga', loadChildren: () => import('src/app/modules/liga-overview/liga-overview.module').then((m) => m.LigaOverviewModule)},
   {path: 'spotter', loadChildren: () => import('src/app/modules/spotter/spotter.module').then((m) => m.SpotterModule)},
   {path: 'schusszettel', loadChildren: () => import('./modules/schusszettel/schusszettel.module').then((m) => m.SchusszettelModule)},

--- a/bogenliga/src/app/components/sidebar/sidebar.component.ts
+++ b/bogenliga/src/app/components/sidebar/sidebar.component.ts
@@ -75,7 +75,7 @@ export class SidebarComponent implements OnInit {
   public getRoute(route: string, detailType: string): string {
     let result: string = route;
     this.URLRoute = this.router.url;
-    if (this.URLRoute.startsWith("/ligatabelle") ||this.URLRoute.startsWith("/home") ) {
+    if (this.URLRoute.startsWith("/home") ) {
       const lastSlashIndex = this.URLRoute.lastIndexOf('/');
       switch(lastSlashIndex){
         case 0:
@@ -99,8 +99,6 @@ export class SidebarComponent implements OnInit {
     }
 
     if (this.ligaID != undefined && route.startsWith("/home")){
-      result =  result + '/'+ this.ligaID.toString();
-    } else if(this.ligaID != undefined && route.startsWith("/ligatabelle")){
       result =  result + '/'+ this.ligaID.toString();
     }
 

--- a/bogenliga/src/app/components/sidebar/sidebar.config.ts
+++ b/bogenliga/src/app/components/sidebar/sidebar.config.ts
@@ -13,7 +13,6 @@ import {
   faCalendarAlt,
   faCode, // faFootballBall,
   faHome,
-  faListOl,
   faSitemap,
   faUsers,
   faQuestion,
@@ -140,14 +139,6 @@ export const SIDE_BAR_CONFIG: SideBarNavigationItem[] = [
     datacy: 'sidebar-ligauebersicht-button'
   },
   {
-    label: 'SIDEBAR.MANNSCHAFTEN',
-    icon: faListOl,
-    route: '/ligatabelle',
-    permissons: [UserPermission.CAN_READ_DEFAULT],
-    subitems: [],
-    datacy: 'sidebar-ligatabelle-button'
-  },
-  {
     label: 'SIDEBAR.SPOTTING',
     icon: faBinoculars,
     route: '/spotter',
@@ -262,14 +253,6 @@ export const SIDE_BAR_CONFIG_OFFLINE: SideBarNavigationItem[] = [
     permissons: [UserPermission.CAN_READ_DEFAULT],
     subitems: [],
     datacy: 'sidebar-ligauebersicht-button'
-  },
-  {
-    label: 'SIDEBAR.MANNSCHAFTEN',
-    icon: faListOl,
-    route: '/ligatabelle',
-    permissons: [UserPermission.CAN_READ_DEFAULT],
-    subitems: [],
-    datacy: 'sidebar-ligatabelle-button'
   },
   {
     label: 'SIDEBAR.SPOTTING',

--- a/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.ts
+++ b/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.ts
@@ -14,8 +14,6 @@ import {LigaDTO} from '@verwaltung/types/datatransfer/liga-dto.class';
 import {VereinDTO} from '@verwaltung/types/datatransfer/verein-dto.class';
 import {RoleVersionedDataObject} from '@verwaltung/services/models/roles-versioned-data-object.class';
 import {Router} from '@angular/router';
-// import {LigatabelleComponent} from '../../../ligatabelle/components/ligatabelle/ligatabelle.component';
-// import {VeranstaltungDO} from '@verwaltung/types/veranstaltung-do.class';
 import {SessionHandling} from '@shared/event-handling';
 import {CurrentUserService, OnOfflineService} from '@shared/services';
 
@@ -327,8 +325,7 @@ export class RegionenComponent implements OnInit {
     this.selectedLigaDO = event[0];
     console.log(this.selectedLigaDO);
     console.log('regionen selectedid: ' + this.selectedLigaDO.id);
-    this.router.navigateByUrl('/ligatabelle/' + this.selectedLigaDO.id);
-    // this.router.navigateByUrl('/ligatabelle');
+    this.router.navigateByUrl('/liga');
   }
 
   public getEmptyList(): RoleVersionedDataObject[] {

--- a/changelogs/README.md
+++ b/changelogs/README.md
@@ -18,6 +18,7 @@ Die Changelogs folgen dem [Keep a Changelog](https://keepachangelog.com/de/1.0.0
 ## Aktuelle Changelogs
 
 - `changelog-2025-11-01-ligauebersicht.md` - Ligaübersicht Modul (Issue #1957-Frontend)
+- `changelog-2025-11-10-entfernung-ligatabelle-navigation.md` - Entfernung Navigation zur alten Ligatabelle
 - `changelog-2025-11-09-league-hierarchy-service.md` - Liga-Hierarchie Service
 - `changelog-2025-11-09-ui-001-tree-component.md` - UI-001 Basis-Baumkomponente
 

--- a/changelogs/changelog-2025-11-10-entfernung-ligatabelle-navigation.md
+++ b/changelogs/changelog-2025-11-10-entfernung-ligatabelle-navigation.md
@@ -1,0 +1,34 @@
+# Changelog
+
+Alle bemerkenswerten Änderungen an diesem Projekt werden in dieser Datei dokumentiert.
+
+Das Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/),
+und dieses Projekt hält sich an [Semantic Versioning](https://semver.org/lang/de/).
+
+## [Unreleased]
+
+## [2025-11-10] - Entfernung der Ligatabelle-Navigation
+
+### Entfernt
+- Routing-Einträge `/ligatabelle` und `/ligatabelle/:id` aus `bogenliga/src/app/app.routing.ts`.
+- Sidebar-Menüpunkte `SIDEBAR.MANNSCHAFTEN` für Online- und Offline-Konfiguration (`bogenliga/src/app/components/sidebar/sidebar.config.ts`).
+
+### Geändert
+- `SidebarComponent`: Routinglogik bereinigt – `/ligatabelle`-Sonderfall entfernt, Analytics-Tracking unverändert (`bogenliga/src/app/components/sidebar/sidebar.component.ts`).
+- `RegionenComponent`: Ligaauswahl navigiert jetzt zur neuen Ligaübersicht `/liga`; auskommentierte Ligatabelle-Referenzen gelöscht (`bogenliga/src/app/modules/regionen/components/regionen/regionen.component.ts`).
+- Dokumentation `ENTFERNUNG_ALTE_LIGATABELLE.md` um Status-Update ergänzt (`bogenliga/ENTFERNUNG_ALTE_LIGATABELLE.md`).
+
+### Technische Details
+- **Commit**: wird nach Merge gesetzt
+- **Autor**: Joshua Jeglinski
+- **Datum**: 2025-11-10
+- **Dateien geändert**: 5 Dateien (aktualisiert)
+
+### Tests
+- `npm run lint` *(nicht ausgeführt – bitte im CI laufen lassen)*
+- Manuelle Schnellprüfung im Browser empfohlen: Sidebar-Navigation öffnen, Ligaauswahl über Regionen testen, direkte URL `/ligatabelle` ansteuern (soll 404 liefern).
+
+### Offene Punkte
+- Restliche Übersetzungen und Rückbau des Ligatabelle-Moduls erfolgen im Zuge von EPIC 4.
+
+


### PR DESCRIPTION
https://gitlab.gras-it.de/hsrt/swt2/-/issues/1976

Entfernung alter Aufrufe  der Ligatabelle, als Vorbereitung für den Rückbau Epic 4