### PR TITLE
Ticket 1980 CSS Fix - Mini-Korrektur

### DIFF
--- a/bogenliga/src/app/modules/schusszettel/components/maske4zustand/maske4zustand.component.scss
+++ b/bogenliga/src/app/modules/schusszettel/components/maske4zustand/maske4zustand.component.scss
@@ -341,6 +341,14 @@ $border: #dee2e6;
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: 8px;
   }
+
+  /* Fix: Anzeige der Schusszettel (Tabelle) Mobile */
+  .embedded-schusszettel-section {
+    display: block !important;
+  }
+  .embedded-schusszettel-section .schusszettel-container {
+    transform-origin: top left !important;
+  }
 }
 
 // Mobile adjustments
@@ -573,7 +581,7 @@ $border: #dee2e6;
 
   @media (max-width: 1199px) {
     .schusszettel-container {
-      transform: scale(0.9);
+      transform: scale(0.8);
     }
   }
 
@@ -629,20 +637,5 @@ $border: #dee2e6;
       border: 1px solid #000;
       box-shadow: none;
     }
-  }
-}
-
-/* Scroll Fix Schusszettel-Uebersicht & Tabelle Mobile */
-@media (max-width: 1024px) {
-  .embedded-schusszettel-section {
-    display: block !important;
-    padding: 0 !important;
-    align-items: flex-start !important;
-    overflow-x: auto !important;
-  }
-  .embedded-schusszettel-section .schusszettel-container {
-    transform-origin: top left !important;
-    display: inline-block !important;
-    margin: 0 !important;
   }
 }

--- a/bogenliga/src/styles.scss
+++ b/bogenliga/src/styles.scss
@@ -77,6 +77,12 @@ body {
   color: $primary-black;
 }
 
+/* Scroll-Fix für Mobile & Fullscreen */
+body {
+  overflow-y: auto !important;
+  -webkit-overflow-scrolling: touch; // iOS
+}
+
 // ==================
 /* GLOBAL TYPOGRAPHY */
 
@@ -414,10 +420,4 @@ a:hover, a:focus {
 
 .action-btn-circle:focus {
   outline: none;
-}
-
-/* Scroll-Fix für Mobile & Fullscreen */
-html, body, app-root {
-  overflow-y: auto !important;
-  -webkit-overflow-scrolling: touch; // iOS
 }


### PR DESCRIPTION
Mini-CSS-Korrektur bei Anzeige der Schusszettel-Tabelle auf Tablet und Smartphone. Die Tabelle wurde bei einer ganz spezifischen Pixelbreite (1025px bis 1050px) noch abgeschnitten angezeigt aufgrund einer bestehenden CSS-Scale-Transformation, die korrigiert wurde.