### PR TITLE
Refactor sidebar and routing: remove 'regionen' path and update 'liga…

### DIFF
--- a/bogenliga/src/app/app.routing.ts
+++ b/bogenliga/src/app/app.routing.ts
@@ -42,7 +42,6 @@ export const ROUTES: Routes = [
   {path: 'wkdurchfuehrung', loadChildren: () => import('src/app/modules/wkdurchfuehrung/wkdurchfuehrung.module').then((m) => m.WkdurchfuehrungModule)},
   {path: 'wkdurchfuehrung/:id', loadChildren: () => import('src/app/modules/wkdurchfuehrung/wkdurchfuehrung.module').then((m) => m.WkdurchfuehrungModule)},
   {path: 'user', loadChildren: () => import('src/app/modules/user/user.module').then((m) => m.UserModule)},
-  {path: 'regionen', loadChildren: () => import('src/app/modules/regionen/regionen.module').then((m) => m.RegionenModule)},
   {path: 'vereine', loadChildren: () => import('src/app/modules/vereine/vereine.module').then((m) => m.VereineModule)},
   {path: 'vereine/:id', loadChildren: () => import('src/app/modules/vereine/vereine.module').then((m) => m.VereineModule)},
   {path: 'playground', loadChildren: () => import('src/app/modules/playground/playground.module').then((m) => m.PlaygroundModule)},

--- a/bogenliga/src/app/components/sidebar/sidebar.config.ts
+++ b/bogenliga/src/app/components/sidebar/sidebar.config.ts
@@ -9,7 +9,6 @@ import {SideBarNavigationItem} from './types/sidebar-navigation-item.interface';
 import {
   faArchive,
   faBinoculars,
-  faBullseye,
   faCalendarAlt,
   faCode, // faFootballBall,
   faHome,
@@ -17,8 +16,6 @@ import {
   faSitemap,
   faUsers,
   faQuestion,
-  faChartBar, // Ligaübersicht
-
   faTrophy, // Wettkämpfe
   faCalendar, // Wettkampfdurchführung
   faCogs, // Verwaltung
@@ -37,12 +34,12 @@ export const SIDE_BAR_CONFIG: SideBarNavigationItem[] = [
   },
 
   {
-    label: 'SIDEBAR.REGIONEN',
-    icon: faBullseye,
-    route: '/regionen',
+    label: 'SIDEBAR.LIGAUEBERSICHT',
+    icon: faSitemap,
+    route: '/liga',
     permissons: [UserPermission.CAN_READ_DEFAULT],
     subitems: [],
-    datacy: 'sidebar-regionen-button'
+    datacy: 'sidebar-ligauebersicht-button'
   },
   {
     label: 'SIDEBAR.VEREINE',
@@ -129,16 +126,7 @@ export const SIDE_BAR_CONFIG: SideBarNavigationItem[] = [
     subitems: [],
     datacy: 'sidebar-wkdurchfuehrung-button'
   },
-
-
-  {
-    label: 'SIDEBAR.LIGAUEBERSICHT',
-    icon: faChartBar,
-    route: '/liga',
-    permissons: [UserPermission.CAN_READ_DEFAULT],
-    subitems: [],
-    datacy: 'sidebar-ligauebersicht-button'
-  },
+ 
   {
     label: 'SIDEBAR.MANNSCHAFTEN',
     icon: faListOl,
@@ -254,14 +242,6 @@ export const SIDE_BAR_CONFIG_OFFLINE: SideBarNavigationItem[] = [
     permissons: [UserPermission.CAN_READ_WETTKAMPF, UserPermission.CAN_MODIFY_WETTKAMPF],
     subitems: [],
     datacy: 'sidebar-wkdurchfuehrung-button'
-  },
-  {
-    label: 'SIDEBAR.LIGAUEBERSICHT',
-    icon: faChartBar,
-    route: '/liga',
-    permissons: [UserPermission.CAN_READ_DEFAULT],
-    subitems: [],
-    datacy: 'sidebar-ligauebersicht-button'
   },
   {
     label: 'SIDEBAR.MANNSCHAFTEN',


### PR DESCRIPTION
https://gitlab.gras-it.de/hsrt/swt2/-/issues/1976

Beschreibung:
Migration der Sidebar-Navigation von der alten Ligahierarchie (/regionen) zur neuen Ligaübersicht (/liga). Der ehemalige "REGIONEN"-Eintrag soll umfunktioniert werden, um auf die neue Ligahierarchie zu verweisen. Der separate "LIGAUEBERSICHT" Eintrag wird entfernt, um Duplikate zu vermeiden. Die Route /regionen soll aus dem Routing entfernt werden , um direkten Zugriff auf die alte Seite zu verhindern, hierdurch entsteht eine direkte Überleitung zu EPIC 4.