### PR TITLE
Ligaübersicht leitet wieder zum Ligahome statt Ligatabelle

### DIFF
--- a/bogenliga/src/app/modules/liga-overview/components/liga-overview/liga-overview.component.ts
+++ b/bogenliga/src/app/modules/liga-overview/components/liga-overview/liga-overview.component.ts
@@ -92,9 +92,9 @@ export class LigaOverviewComponent implements OnInit, OnDestroy {
     this.selectedLigaId = ligaId;
     this.trackSelection(ligaId);
 
-    // Neue, kanonische Navigation: /ligatabelle?liga=<id>
+    // Navigation zur jeweiligen Liga-Home-Seite: /home?liga=<id>
     this.router.navigate(
-      ['/ligatabelle'],
+      ['/home'],
       {
         queryParams: { liga: ligaId },
         queryParamsHandling: 'merge'


### PR DESCRIPTION
Habe eine Änderung wieder Rückgängig gemacht, die von einer anderen Gruppe gemacht wurde und unseren Route geändert hat. Er führte, statt wie vorgesehen, auf das Ligahome der einzelnen Ligas zur Ligatabelle