### PR TITLE
#2005: Ligatabelle-Button erscheint nur nach Liga-Auswahl; Ligadetails- und …

### DIFF
--- a/bogenliga/src/app/components/sidebar/sidebar.component.html
+++ b/bogenliga/src/app/components/sidebar/sidebar.component.html
@@ -10,7 +10,9 @@
     <!-- Sidebar links config -->
     <nav class="list-unstyled components">
       <ng-container *ngFor="let item of CONFIG">
-        <li *ngIf="hasUserPermissions(item.permissons) && !(inProd === true && item.inProdVisible === false)"
+        <li *ngIf="hasUserPermissions(item.permissons)
+                   && !(inProd === true && item.inProdVisible === false)
+                   && (item.route !== '/ligatabelle' || hasActiveLigaContext())"
             [class.selected]="isSelected(item.route)">
 
           <!-- Haupt-Item -->

--- a/bogenliga/src/app/components/sidebar/sidebar.component.ts
+++ b/bogenliga/src/app/components/sidebar/sidebar.component.ts
@@ -163,6 +163,15 @@ export class SidebarComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Ist ein Liga-Kontext aktiv?
+   * Prüft currentLiga oder (als Fallback) den gemerkten Kontext im Service.
+   */
+  public hasActiveLigaContext(): boolean {
+    const source = this.currentLiga ?? this.ligaContext.remembered;
+    return !!source?.id;
+  }
+
+  /**
    * Tracked Navigationsklicks für Analytics (Matomo/Piwik)
    *
    * @param route Die aufgerufene Route

--- a/bogenliga/src/app/modules/ligatabelle/components/ligatabelle/ligatabelle.component.html
+++ b/bogenliga/src/app/modules/ligatabelle/components/ligatabelle/ligatabelle.component.html
@@ -94,7 +94,8 @@
             {{ selectedVeranstaltungName}}
           </bla-actionbutton>
 
-          <!-- Button - Zu den Ligadetails -->
+          <!-- Button - Zu den Ligadetails (Deprecated, ersetzt durch Liga-Home) -->
+          <!--
           <bla-actionbutton
             [id]="'goToLigadetailsButton'"
             [color]= "ActionButtonColors.PRIMARY"
@@ -102,8 +103,10 @@
             (onClick)="goToLigaDetails()">
             {{ 'WETTKAEMPFE.LIGATABELLE.GOTO_LIGADETAILS' | translate }}
           </bla-actionbutton>
+          -->
 
-          <!-- Button - Auswahl zurücksetzen -->
+          <!-- Button - Auswahl zurücksetzen (Deprecated) -->
+          <!--
           <bla-actionbutton
             [id]="'deselectLigaButton'"
             [color]= "ActionButtonColors.SECONDARY"
@@ -111,6 +114,7 @@
             (onClick)="deselect()">
             {{ 'WETTKAEMPFE.LIGATABELLE.RESET_LIGASELECTION' | translate }}
           </bla-actionbutton>
+          -->
 
         </div>
         <div class="col-sm-9">


### PR DESCRIPTION
…unsichtbarer Zurücksetzen-Button von der Ligatabelle entfernt

https://gitlab.gras-it.de/hsrt/swt2/-/issues/2005