### PR TITLE
Improve responsiveness of league overview components

### DIFF
--- a/bogenliga/src/app/modules/liga-overview/components/liga-overview/liga-overview.component.html
+++ b/bogenliga/src/app/modules/liga-overview/components/liga-overview/liga-overview.component.html
@@ -1,6 +1,6 @@
 <bla-common-dialog [config]="config">
   <div class="content">
-    <div class="container">
+    <div class="container-fluid">
       <div class="row">
         <div class="col">
           <p>{{ 'LIGAUEBERSICHT.DESCRIPTION' | translate }}</p>

--- a/bogenliga/src/app/modules/liga-overview/components/liga-overview/liga-overview.component.scss
+++ b/bogenliga/src/app/modules/liga-overview/components/liga-overview/liga-overview.component.scss
@@ -14,9 +14,14 @@
 .liga-tree-wrapper {
   border: 1px solid rgba(0, 0, 0, 0.08);
   border-radius: 8px;
-  padding: 12px;
+  padding: 24px 16px;
   background-color: #fff;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+  width: 100%;
+  box-sizing: border-box;
+  /* Horizontal scroll only as last resort for extreme hierarchies */
+  overflow-x: auto;
+  overflow-y: visible;
 }
 
 .liga-tree-state {
@@ -25,4 +30,20 @@
   gap: 0.5rem;
   font-size: 0.95rem;
   margin-top: 16px;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .content {
+    padding: 12px;
+  }
+
+  .liga-tree-wrapper {
+    padding: 16px 8px;
+    border-radius: 4px;
+  }
+
+  .liga-tree-section {
+    margin-top: 16px;
+  }
 }

--- a/bogenliga/src/app/modules/liga-overview/components/tree/tree-node.component.scss
+++ b/bogenliga/src/app/modules/liga-overview/components/tree/tree-node.component.scss
@@ -3,10 +3,9 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  flex: 1 1 auto;
-  min-width: 180px;
-  max-width: 400px;
-  padding: 0 calc(var(--bla-tree-node-gap, 24px) / 2);
+  flex: 0 0 auto;
+  min-width: max-content;
+  padding: 0 calc(var(--bla-tree-node-gap, 16px) / 2);
   box-sizing: border-box;
   outline: none;
 }
@@ -54,17 +53,20 @@
   position: relative;
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  min-height: var(--bla-tree-row-height, 52px);
-  padding: 0.75rem 1.5rem;
+  gap: 0.4rem;
+  min-height: var(--bla-tree-row-height, 40px);
+  padding: 0.4rem 0.6rem;
   cursor: pointer;
-  border-radius: var(--bla-tree-border-radius, 8px);
+  border-radius: var(--bla-tree-border-radius, 6px);
   box-shadow: var(--bla-tree-card-shadow);
   border: 1px solid var(--bla-tree-level-default-border);
   background: var(--bla-tree-level-default-bg);
   color: var(--bla-tree-level-default-foreground, #1d2533);
   transition: box-shadow 160ms ease, transform 160ms ease;
-  width: 100%;
+  width: auto;
+  min-width: 150px;
+  max-width: 220px;
+  margin: 0 auto;
 }
 
 .bla-league-tree__item-row:hover {
@@ -92,10 +94,10 @@
 }
 
 .bla-league-tree__toggle {
-  width: 40px;
-  height: 40px;
-  min-width: 40px;
-  min-height: 40px;
+  width: 28px;
+  height: 28px;
+  min-width: 28px;
+  min-height: 28px;
   border: none;
   border-radius: 50%;
   display: inline-flex;
@@ -117,10 +119,10 @@
 }
 
 .bla-league-tree__toggle-placeholder {
-  width: 40px;
-  height: 40px;
+  width: 28px;
+  height: 28px;
   display: inline-flex;
-  flex: 0 0 40px;
+  flex: 0 0 28px;
 }
 
 .bla-league-tree__toggle-icon {
@@ -167,6 +169,7 @@
   list-style: none;
   display: flex;
   justify-content: center;
+  gap: 0;
   position: relative;
 }
 
@@ -175,7 +178,7 @@
   position: relative;
   display: flex;
   justify-content: center;
-  flex: 1 1 auto;
+  flex: 0 0 auto;
 }
 
 :host(.bla-league-tree__item--has-children.bla-league-tree__item--expanded) .bla-league-tree__item-row::after {

--- a/bogenliga/src/app/modules/liga-overview/components/tree/tree-node.component.scss
+++ b/bogenliga/src/app/modules/liga-overview/components/tree/tree-node.component.scss
@@ -3,10 +3,10 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  flex: 1 1 260px;
-  min-width: 240px;
-  max-width: 320px;
-  padding: 0 calc(var(--bla-tree-node-gap, 32px) / 2);
+  flex: 1 1 auto;
+  min-width: 180px;
+  max-width: 400px;
+  padding: 0 calc(var(--bla-tree-node-gap, 24px) / 2);
   box-sizing: border-box;
   outline: none;
 }
@@ -84,9 +84,9 @@
 
 .bla-league-tree__label {
   flex: 1 1 auto;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  hyphens: auto;
   font-weight: 600;
   letter-spacing: 0.01em;
 }
@@ -230,19 +230,31 @@
 
 @media (max-width: 992px) {
   :host {
-    padding: 0 calc(var(--bla-tree-node-gap, 32px) / 3);
-    min-width: 180px;
-    max-width: 240px;
+    padding: 0 calc(var(--bla-tree-node-gap, 24px) / 4);
+    min-width: 160px;
+    max-width: 100%;
   }
 
   .bla-league-tree__item-row {
     width: 100%;
-    padding: 0.75rem 1.25rem;
+    padding: 0.75rem 1rem;
   }
 
   .bla-league-tree__group {
     flex-wrap: wrap;
-    row-gap: calc(var(--bla-tree-node-gap, 32px) / 1.5);
+    row-gap: calc(var(--bla-tree-node-gap, 24px) / 1.5);
   }
 }
 
+@media (max-width: 576px) {
+  :host {
+    min-width: 100%;
+    max-width: 100%;
+    padding: 0;
+  }
+
+  .bla-league-tree__item-row {
+    padding: 0.625rem 0.875rem;
+    min-height: 44px;
+  }
+}

--- a/bogenliga/src/app/modules/liga-overview/components/tree/tree.component.scss
+++ b/bogenliga/src/app/modules/liga-overview/components/tree/tree.component.scss
@@ -1,9 +1,6 @@
 :host {
   display: block;
-}
-
-:host {
-  display: block;
+  width: 100%;
 }
 
 .bla-league-tree {
@@ -12,8 +9,8 @@
   --bla-tree-selected-bg: rgba(44, 123, 229, 0.16);
   --bla-tree-border-radius: 8px;
   --bla-tree-row-height: 52px;
-  --bla-tree-node-gap: 32px;
-  --bla-tree-branch-length: 32px;
+  --bla-tree-node-gap: 24px;
+  --bla-tree-branch-length: 28px;
   --bla-tree-branch-color: #d8dde8;
   --bla-tree-level-0-bg: #d62828;
   --bla-tree-level-0-border: #b71f21;
@@ -33,7 +30,7 @@
   font-size: 15px;
   line-height: 1.4;
   width: 100%;
-  overflow-x: auto;
+  min-width: 0;
   padding-bottom: 24px;
 }
 
@@ -42,7 +39,9 @@
   padding: 0;
   list-style: none;
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
+  gap: var(--bla-tree-node-gap);
 }
 
 .bla-league-tree__root-item {
@@ -51,5 +50,24 @@
   display: flex;
   justify-content: center;
   flex: 1 1 auto;
+  min-width: 200px;
+  max-width: 100%;
 }
 
+/* Tablet and below: stack vertically */
+@media (max-width: 992px) {
+  .bla-league-tree {
+    --bla-tree-node-gap: 16px;
+    --bla-tree-branch-length: 20px;
+  }
+
+  .bla-league-tree__list {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .bla-league-tree__root-item {
+    min-width: 100%;
+    max-width: 100%;
+  }
+}

--- a/bogenliga/src/app/modules/liga-overview/components/tree/tree.component.scss
+++ b/bogenliga/src/app/modules/liga-overview/components/tree/tree.component.scss
@@ -7,10 +7,10 @@
   --bla-tree-focus-ring: 2px solid var(--bla-color-focus, #2c7be5);
   --bla-tree-hover-bg: rgba(44, 123, 229, 0.08);
   --bla-tree-selected-bg: rgba(44, 123, 229, 0.16);
-  --bla-tree-border-radius: 8px;
-  --bla-tree-row-height: 52px;
-  --bla-tree-node-gap: 24px;
-  --bla-tree-branch-length: 28px;
+  --bla-tree-border-radius: 6px;
+  --bla-tree-row-height: 48px;
+  --bla-tree-node-gap: 16px;
+  --bla-tree-branch-length: 24px;
   --bla-tree-branch-color: #d8dde8;
   --bla-tree-level-0-bg: #d62828;
   --bla-tree-level-0-border: #b71f21;
@@ -25,12 +25,12 @@
   --bla-tree-level-default-bg: #ffffff;
   --bla-tree-level-default-border: #d1d6e0;
   --bla-tree-level-default-foreground: #1d2533;
-  --bla-tree-card-shadow: 0 8px 16px rgba(18, 33, 54, 0.12);
+  --bla-tree-card-shadow: 0 4px 10px rgba(18, 33, 54, 0.1);
 
-  font-size: 15px;
+  font-size: 13px;
   line-height: 1.4;
-  width: 100%;
-  min-width: 0;
+  width: fit-content;
+  min-width: 100%;
   padding-bottom: 24px;
 }
 
@@ -39,9 +39,10 @@
   padding: 0;
   list-style: none;
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   justify-content: center;
-  gap: var(--bla-tree-node-gap);
+  gap: 0;
+  width: 100%;
 }
 
 .bla-league-tree__root-item {
@@ -49,9 +50,7 @@
   position: relative;
   display: flex;
   justify-content: center;
-  flex: 1 1 auto;
-  min-width: 200px;
-  max-width: 100%;
+  flex: 0 0 auto;
 }
 
 /* Tablet and below: stack vertically */


### PR DESCRIPTION
https://gitlab.gras-it.de/hsrt/swt2/-/issues/2006
This pull request focuses on improving the layout, responsiveness, and readability of the league overview and tree components. The changes enhance the user experience on various screen sizes, ensure better text wrapping, and refine spacing for a cleaner appearance.

**Layout and Responsiveness Improvements:**

* Changed container classes in `liga-overview.component.html` from `container` to `container-fluid` for full-width layouts.
* Added responsive styles to `liga-overview.component.scss`, adjusting paddings, border radii, and margins for better appearance on smaller screens. [[1]](diffhunk://#diff-2fdd8b23edfa7f8c711b6e789ab7a1010dd4477b783bdc8f6fbf448d229298f4L17-R24) [[2]](diffhunk://#diff-2fdd8b23edfa7f8c711b6e789ab7a1010dd4477b783bdc8f6fbf448d229298f4R34-R49)
* Updated tree component styles to ensure full-width layouts and responsive stacking of nodes on tablets and smaller devices. [[1]](diffhunk://#diff-af8415b279e0ab3588addc4b87ae58a201d2395ff578f15b6b7339a952273447L3-R3) [[2]](diffhunk://#diff-af8415b279e0ab3588addc4b87ae58a201d2395ff578f15b6b7339a952273447R53-R73)
* Adjusted variables for spacing and branch lengths to scale better across devices.

**Tree Node and Label Enhancements:**

* Improved `tree-node.component.scss` for flexible sizing, reduced minimum widths, increased maximum widths, and refined padding for better fit and appearance. [[1]](diffhunk://#diff-9647de42d71c55bee152036d69a7d1f74de5e5794ee545a223824aab557b633cL6-R9) [[2]](diffhunk://#diff-9647de42d71c55bee152036d69a7d1f74de5e5794ee545a223824aab557b633cL233-R260)
* Enhanced label wrapping in tree nodes, replacing ellipsis overflow with proper word breaking and hyphenation for improved readability of long names.

**Visual and Structural Refinements:**

* Updated the tree list to use `flex-wrap` and `gap` for neater alignment and spacing between nodes.
* Removed unnecessary horizontal scrolling and set minimum widths for better containment and appearance.