### PR TITLE
WKDurchfuehrung Schusszettel-Eingabe Fix

### DIFF
--- a/bogenliga/src/app/modules/verwaltung/services/mannschaftsmitglied-data-provider.service.ts
+++ b/bogenliga/src/app/modules/verwaltung/services/mannschaftsmitglied-data-provider.service.ts
@@ -51,7 +51,7 @@ export class MannschaftsmitgliedDataProviderService extends DataProviderService 
               });
               console.log(key);
             });
-          const  neuesMannschaftsmitglied = fromDOToOfflineMannschaftsmitglied(payload, key);
+          const neuesMannschaftsmitglied = fromDOToOfflineMannschaftsmitglied(payload, key);
           neuesMannschaftsmitglied.offlineVersion = 2;
           await db.mannschaftsmitgliedTabelle.put(neuesMannschaftsmitglied, key);
 
@@ -70,17 +70,17 @@ export class MannschaftsmitgliedDataProviderService extends DataProviderService 
       // sign in failure -> reject promise with result
       return new Promise((resolve, reject) => {
         this.restClient.POST<VersionedDataTransferObject>(new UriBuilder().fromPath(this.getUrl()).build(), payload)
-            .then((data: VersionedDataTransferObject) => {
-              resolve({result: RequestResult.SUCCESS, payload: fromPayload(data)});
+          .then((data: VersionedDataTransferObject) => {
+            resolve({result: RequestResult.SUCCESS, payload: fromPayload(data)});
 
-            }, (error: HttpErrorResponse) => {
+          }, (error: HttpErrorResponse) => {
 
-              if (error.status === 0) {
-                reject({result: RequestResult.CONNECTION_PROBLEM});
-              } else {
-                reject({result: RequestResult.FAILURE});
-              }
-            });
+            if (error.status === 0) {
+              reject({result: RequestResult.CONNECTION_PROBLEM});
+            } else {
+              reject({result: RequestResult.FAILURE});
+            }
+          });
       });
     }
   }
@@ -123,17 +123,17 @@ export class MannschaftsmitgliedDataProviderService extends DataProviderService 
       // sign in failure -> reject promise with result
       return new Promise((resolve, reject) => {
         this.restClient.DELETE<void>(new UriBuilder().fromPath(this.getUrl()).path(teamId + '/' + memberId).build())
-            .then((noData) => {
-              resolve({result: RequestResult.SUCCESS});
+          .then((noData) => {
+            resolve({result: RequestResult.SUCCESS});
 
-            }, (error: HttpErrorResponse) => {
+          }, (error: HttpErrorResponse) => {
 
-              if (error.status === 0) {
-                reject({result: RequestResult.CONNECTION_PROBLEM});
-              } else {
-                reject({result: RequestResult.FAILURE});
-              }
-            });
+            if (error.status === 0) {
+              reject({result: RequestResult.CONNECTION_PROBLEM});
+            } else {
+              reject({result: RequestResult.FAILURE});
+            }
+          });
       });
     }
   }
@@ -199,18 +199,18 @@ export class MannschaftsmitgliedDataProviderService extends DataProviderService 
       // sign in failure -> resolve promise with result
       return new Promise((resolve, reject) => {
         this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('byMemberId/' + id).build())
-            .then((data: VersionedDataTransferObject[]) => {
+          .then((data: VersionedDataTransferObject[]) => {
 
-              resolve({result: RequestResult.SUCCESS, payload: fromPayloadArray(data)});
+            resolve({result: RequestResult.SUCCESS, payload: fromPayloadArray(data)});
 
-            }, (error: HttpErrorResponse) => {
+          }, (error: HttpErrorResponse) => {
 
-              if (error.status === 0) {
-                reject({result: RequestResult.CONNECTION_PROBLEM});
-              } else {
-                reject({result: RequestResult.FAILURE});
-              }
-            });
+            if (error.status === 0) {
+              reject({result: RequestResult.CONNECTION_PROBLEM});
+            } else {
+              reject({result: RequestResult.FAILURE});
+            }
+          });
       });
     }
   }
@@ -243,29 +243,6 @@ export class MannschaftsmitgliedDataProviderService extends DataProviderService 
       // sign in failure -> resolve promise with result
       return new Promise((resolve, reject) => {
         this.restClient.GET<VersionedDataTransferObject>(new UriBuilder().fromPath(this.getUrl()).path(memberId).path(teamId).build())
-            .then((data: VersionedDataTransferObject) => {
-
-              resolve({result: RequestResult.SUCCESS, payload: fromPayload(data)});
-
-            }, (error: HttpErrorResponse) => {
-
-              if (error.status === 0) {
-                reject({result: RequestResult.CONNECTION_PROBLEM});
-              } else {
-                reject({result: RequestResult.FAILURE});
-              }
-            });
-      });
-    }
-  }
-
-  public findByTeamIdAndRueckennummer(teamId: string | number, rueckennummer: string | number): Promise<BogenligaResponse<MannschaftsMitgliedDO>> {
-    // return promise
-    // sign in success -> resolve promise
-    // sign in failure -> resolve promise with result
-    return new Promise((resolve, reject) => {
-      this.restClient.GET<VersionedDataTransferObject>(new UriBuilder()
-        .fromPath(this.getUrl()).path(teamId).path('byRueckennummer').path(rueckennummer).build())
           .then((data: VersionedDataTransferObject) => {
 
             resolve({result: RequestResult.SUCCESS, payload: fromPayload(data)});
@@ -278,6 +255,29 @@ export class MannschaftsmitgliedDataProviderService extends DataProviderService 
               reject({result: RequestResult.FAILURE});
             }
           });
+      });
+    }
+  }
+
+  public findByTeamIdAndRueckennummer(teamId: string | number, rueckennummer: string | number): Promise<BogenligaResponse<MannschaftsMitgliedDO>> {
+    // return promise
+    // sign in success -> resolve promise
+    // sign in failure -> resolve promise with result
+    return new Promise((resolve, reject) => {
+      this.restClient.GET<VersionedDataTransferObject>(new UriBuilder()
+        .fromPath(this.getUrl()).path(teamId).path('byRueckennummer').path(rueckennummer).build())
+        .then((data: VersionedDataTransferObject) => {
+
+          resolve({result: RequestResult.SUCCESS, payload: fromPayload(data)});
+
+        }, (error: HttpErrorResponse) => {
+
+          if (error.status === 0) {
+            reject({result: RequestResult.CONNECTION_PROBLEM, status: error.status});
+          } else {
+            reject({result: RequestResult.FAILURE, status: error.status});
+          }
+        });
     });
   }
 
@@ -298,21 +298,22 @@ export class MannschaftsmitgliedDataProviderService extends DataProviderService 
       // sign in failure -> resolve promise with result
       return new Promise((resolve, reject) => {
         this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path(id).build())
-            .then((data: VersionedDataTransferObject[]) => {
+          .then((data: VersionedDataTransferObject[]) => {
 
-              resolve({result: RequestResult.SUCCESS, payload: fromPayloadArray(data)});
+            resolve({result: RequestResult.SUCCESS, payload: fromPayloadArray(data)});
 
-            }, (error: HttpErrorResponse) => {
+          }, (error: HttpErrorResponse) => {
 
-              if (error.status === 0) {
-                reject({result: RequestResult.CONNECTION_PROBLEM});
-              } else {
-                reject({result: RequestResult.FAILURE});
-              }
-            });
+            if (error.status === 0) {
+              reject({result: RequestResult.CONNECTION_PROBLEM});
+            } else {
+              reject({result: RequestResult.FAILURE});
+            }
+          });
       });
     }
   }
+
   public save(payload: MannschaftsMitgliedDO): Promise<BogenligaResponse<MannschaftsMitgliedDO>> {
     if (this.onOfflineService.isOffline()) {
       console.log('Choosing offline way for findAllByTeamId');
@@ -331,20 +332,21 @@ export class MannschaftsmitgliedDataProviderService extends DataProviderService 
     } else {
       return new Promise((resolve, reject) => {
         this.restClient.POST<MannschaftsMitgliedDO>(new UriBuilder().fromPath(this.getUrl()).build(), payload)
-            .then((data: MannschaftsMitgliedDO) => {
-              resolve({result: RequestResult.SUCCESS, payload: fromPayload(data)});
+          .then((data: MannschaftsMitgliedDO) => {
+            resolve({result: RequestResult.SUCCESS, payload: fromPayload(data)});
 
-            }, (error: HttpErrorResponse) => {
+          }, (error: HttpErrorResponse) => {
 
-              if (error.status === 0) {
-                reject({result: RequestResult.CONNECTION_PROBLEM});
-              } else {
-                reject({result: RequestResult.FAILURE});
-              }
-            });
+            if (error.status === 0) {
+              reject({result: RequestResult.CONNECTION_PROBLEM});
+            } else {
+              reject({result: RequestResult.FAILURE});
+            }
+          });
       });
     }
   }
+
   public update(payload: MannschaftsMitgliedDO): Promise<BogenligaResponse<MannschaftsMitgliedDO>> {
     // return promise
     // sign in success -> resolve promise

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.html
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.html
@@ -1,8 +1,11 @@
 <!-- Container -->
 <div
   class="schusszettel-container"
-  *ngIf="hasRingzahlen(match1) || hasRingzahlen(match2)"
   [class.readonly-mode]="readOnlyMode">
+  <!-- <div
+    class="schusszettel-container"
+    *ngIf="hasRingzahlen(match1) || hasRingzahlen(match2)"
+    [class.readonly-mode]="readOnlyMode"> -->
   <!-- Match 1 -->
   <div class="match-section">
     <!-- Header Row -->
@@ -499,9 +502,9 @@
     </div>
   </div>
 </div>
-<div
+<!-- <div
   class="schusszettel-container-note"
   *ngIf="match1 && match2 && !hasRingzahlen(match1) && !hasRingzahlen(match2)">
   <p>Detaillierte Schusszettel-Informationen sind derzeit nicht verfügbar, da noch keine Match-Ergebnisse eingetragen
     wurden.</p>
-</div>
+</div> -->

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
@@ -320,13 +320,6 @@ export class SchusszettelComponent implements OnInit {
 
     const previousValue = this.lastRueckennummer;
 
-    console.log(
-      `👤 Rückennummer geändert → Match ${matchNr}, Schütze ${schuetzeIndex}, Satz ${satzIndex}:`,
-      newValue,
-      '| vorher:',
-      previousValue
-    );
-
     if (newValue == null || newValue === 0) {
       inputElement.value = previousValue ? String(previousValue) : '';
       return;
@@ -382,8 +375,22 @@ export class SchusszettelComponent implements OnInit {
       this.dirtyFlag = true;
 
     } catch (e) {
+
       match.schuetzen[schuetzeIndex][0].rueckennummer = previousValue;
       inputElement.value = previousValue ? String(previousValue) : '';
+
+      if (e?.status === 404) {
+        this.notificationService.showNotification({
+          id: 'SCHUETZE_NOT_FOUND',
+          title: 'Rückennummer nicht gefunden',
+          description: `Rückennummer ${newValue} existiert nicht in dieser Mannschaft.`,
+          severity: NotificationSeverity.ERROR,
+          origin: NotificationOrigin.SYSTEM,
+          type: NotificationType.OK,
+          userAction: NotificationUserAction.ACCEPTED
+        });
+        return;
+      }
 
       this.notificationService.showNotification({
         id: 'SCHUETZE_LOOKUP_ERROR',


### PR DESCRIPTION
Mini-Fix WKDurchfuehrung Schusszettel-Eingabe:

- Korrekte Übergabe HTTP Status-Code in findByTeamIdAndRueckennummer, um Fehlermeldung im Frontend bei Eingabe einer Rückennummer korrekt anzeigen zu können.
- Conditional Rendering in Schusszettel HTML Component entfernt, da Schusszettel-Eingabe auch bei leerer Tabelle möglich sein muss. Die Tablet-Eingabe wird nicht immer verwendet.
- Fehlermeldung-Abfrage in onSchuetzeChange()