### PR TITLE
Edit-Funktion für initiale Ligatabelle

### DIFF
--- a/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/veranstaltung-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/veranstaltung-detail.component.ts
@@ -896,11 +896,6 @@ export class VeranstaltungDetailComponent extends CommonComponentDirective imple
   private handleLigatabelleExistsSuccess(response: BogenligaResponse<LigatabelleErgebnisDO[]>) {
     try {
       this.currentLigatabelle = response.payload;
-      for (let i = 0; i < this.rows.length; i++) {
-        const row = this.rows[i];
-        row.disabledActions.push(TableActionType.EDIT);
-        row.hiddenActions.push(TableActionType.EDIT);
-      }
       this.saveLoading = false;
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
 auch bei laufenden Ligen aktiviert, damit "Vorteil" bei Punkte-Gleichstand gepflegt werden kann.