### PR TITLE
2013 - Schützen-Auswahl als Dropdown anstatt Input-Feld

### DIFF
--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/index.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/index.ts
@@ -1,7 +1,7 @@
 export * from './wkdurchfuehrung/wkdurchfuehrung.component';
 export * from './schusszettel/schusszettel.component';
 export * from './schusszettel/number.directive';
-export {RingzahlTabIndexDirective, SchuetzenTabIndexDirective} from './schusszettel/tabindex.directive';
+export {RingzahlTabIndexDirective} from './schusszettel/tabindex.directive';
 export * from './tablet-admin/tablet-admin.component';
 export * from './tableteingabe/tableteingabe.component';
 export * from './fullscreen/fullscreen.component';

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/number.directive.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/number.directive.ts
@@ -139,24 +139,6 @@ export class PfeilNumberOnlyDirective extends NumberOnlyDirective {
   }
 }
 
-/**
- * A element-directive to ensure only-number inputs in passe.schuetzeNr fields.
- * Extends NumberOnlyDirective
- */
-@Directive({
-  selector: '[blaSchuetzeNumberOnly]'
-})
-export class SchuetzeNumberOnlyDirective extends NumberOnlyDirective {
-
-  constructor(el: ElementRef, notificationService: NotificationService) {
-    super(el, ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'], 1, 99, notificationService);
-  }
-
-  @HostListener('keydown', ['$event'])
-  onKeyDown(event: KeyboardEvent) {
-    super.handleKeyDown(event);
-  }
-}
 
 /**
  * A element-directive to ensure only-number inputs in match.fehlerpunkte fields.

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.html
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.html
@@ -2,10 +2,6 @@
 <div
   class="schusszettel-container"
   [class.readonly-mode]="readOnlyMode">
-  <!-- <div
-    class="schusszettel-container"
-    *ngIf="hasRingzahlen(match1) || hasRingzahlen(match2)"
-    [class.readonly-mode]="readOnlyMode"> -->
   <!-- Match 1 -->
   <div class="match-section">
     <!-- Header Row -->
@@ -24,7 +20,6 @@
             match2.mannschaftName
           }}
         </h3>
-        <!-- <p *ngIf="embeddedMode">Tablet-Modus</p> -->
       </div>
       <!-- 2 Table -->
       <div class="col-6">
@@ -125,15 +120,19 @@
             <tr>
               <ng-template ngFor let-j="index" let-passe [ngForOf]="schuetze">
                 <td *ngIf="j === 0">
-                  <input
+                  <select
                     [(ngModel)]="passe.rueckennummer"
-                    (input)="onSchuetzeChange($event, 1, i, j)"
-                    (focus)="rememberOldValue(passe.rueckennummer)"
-                    blaSchuetzeNumberOnly
-                    blaSchuetzenTabIndexDirective
-                    type="number"
-                    [readOnly]="readOnlyMode"
-                  />
+                    (ngModelChange)="onSchuetzeChangeDropdown($event, 1, i, j)"
+                    [disabled]="readOnlyMode"
+                    class="schuetze-select"
+                  >
+                    <option [ngValue]="null">–</option>
+                    <option
+                      *ngFor="let nr of getAvailableRueckennummernMatch1(i)"
+                      [ngValue]="nr">
+                      {{ nr }}
+                    </option>
+                  </select>
                 </td>
                 <td class="split">
                   <input
@@ -206,7 +205,6 @@
   </div>
   <!-- Trennlinie -->
   <hr class="hr-divider"/>
-  <!-- match2 - Now shown in embedded mode too -->
   <!-- Match 2 -->
   <div class="match-section">
     <!-- Header Row -->
@@ -225,7 +223,6 @@
             match1.mannschaftName
           }}
         </h3>
-        <!-- <p *ngIf="embeddedMode">Tablet-Modus</p> -->
       </div>
       <!-- 2 Table -->
       <div class="col-6">
@@ -325,15 +322,19 @@
             <tr>
               <ng-template ngFor let-j="index" let-passe [ngForOf]="schuetze">
                 <td *ngIf="j === 0">
-                  <input
+                  <select
                     [(ngModel)]="passe.rueckennummer"
-                    (input)="onSchuetzeChange($event, 2, i, j)"
-                    (focus)="rememberOldValue(passe.rueckennummer)"
-                    blaSchuetzeNumberOnly
-                    blaSchuetzenTabIndexDirective
-                    type="number"
-                    [readOnly]="readOnlyMode"
-                  />
+                    (ngModelChange)="onSchuetzeChangeDropdown($event, 2, i, j)"
+                    [disabled]="readOnlyMode"
+                    class="schuetze-select"
+                  >
+                    <option [ngValue]="null">–</option>
+                    <option
+                      *ngFor="let nr of getAvailableRueckennummernMatch2(i)"
+                      [ngValue]="nr">
+                      {{ nr }}
+                    </option>
+                  </select>
                 </td>
                 <td class="split">
                   <input
@@ -502,9 +503,3 @@
     </div>
   </div>
 </div>
-<!-- <div
-  class="schusszettel-container-note"
-  *ngIf="match1 && match2 && !hasRingzahlen(match1) && !hasRingzahlen(match2)">
-  <p>Detaillierte Schusszettel-Informationen sind derzeit nicht verfügbar, da noch keine Match-Ergebnisse eingetragen
-    wurden.</p>
-</div> -->

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.scss
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.scss
@@ -197,3 +197,12 @@ input {
   display: flex;
   justify-content: space-between;
 }
+
+.schuetze-select {
+  width: 50px;
+  height: 50px;
+  padding: 0;
+  text-align: center;
+  font-size: 25px;
+  box-sizing: border-box;
+}

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.scss
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.scss
@@ -55,13 +55,13 @@ $secondary-dark: #ff833a; // hover Links, Logo
 }
 
 .table {
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  // box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
   text-align: center;
 }
 
 .table th,
 .table td {
-  border: 1px solid #ffffff;
+  border: 1px solid #ebebeb;
   padding: 5px;
   vertical-align: middle;
   font-size: 12px;

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.scss
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.scss
@@ -61,7 +61,7 @@ $secondary-dark: #ff833a; // hover Links, Logo
 
 .table th,
 .table td {
-  border: 1px solid #e5e7eb;
+  border: 1px solid #ffffff;
   padding: 5px;
   vertical-align: middle;
   font-size: 12px;
@@ -80,12 +80,12 @@ $secondary-dark: #ff833a; // hover Links, Logo
 }
 
 .table thead th {
-  background: #f8f9fb;
+  background: #ffffff;
   font-weight: 600;
 }
 
 .total-row {
-  background: #f8f9fb;
+  background: #ffffff;
 }
 
 .total-row td {

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.scss
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.scss
@@ -199,10 +199,10 @@ input {
 }
 
 .schuetze-select {
-  width: 50px;
-  height: 50px;
+  height: 52px;
+  width: 52px;
   padding: 0;
   text-align: center;
-  font-size: 25px;
+  font-size: 30px;
   box-sizing: border-box;
 }

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
@@ -124,8 +124,8 @@ export class SchusszettelComponent implements OnInit {
     // am Anfang sind keine Änderungen
     this.dirtyFlag = false;
     // this.initSchuetzen();
-    this.initSchuetzenMatch1();
-    this.initSchuetzenMatch2();
+    // this.initSchuetzenMatch1();
+    // this.initSchuetzenMatch2();
 
     // Handle both input properties (embedded mode) and route parameters
     const loadMatches = (match1id: number, match2id: number) => {
@@ -196,7 +196,7 @@ export class SchusszettelComponent implements OnInit {
             }
 
             for (let i = 0; i < 3; i++) {
-              if (this.match2.schuetzen[i].length > 5 && this.match1.schuetzen[i].length !== 0) {
+              if (this.match2.schuetzen[i].length > 5 && this.match2.schuetzen[i].length !== 0) {
                 for (let j = this.match2.schuetzen[i].length; j > 5; j--) {
                   this.match2.schuetzen[i].pop();
                 }
@@ -212,12 +212,12 @@ export class SchusszettelComponent implements OnInit {
           this.initialUsed1 = this.match1.schuetzen.map(s => s[0].rueckennummer);
           this.initialUsed2 = this.match2.schuetzen.map(s => s[0].rueckennummer);
 
-          if (this.match1.schuetzen.length <= 0) {
+          if (!this.match1.schuetzen || this.match1.schuetzen.length === 0) {
             this.initSchuetzenMatch1();
             shouldInitSumSatz = false;
           }
 
-          if (this.match2.schuetzen.length <= 0) {
+          if (!this.match2.schuetzen || this.match2.schuetzen.length === 0) {
             this.initSchuetzenMatch2();
             shouldInitSumSatz = false;
           }
@@ -312,23 +312,30 @@ export class SchusszettelComponent implements OnInit {
 
     const match = this['match' + matchNr];
 
+    // Prüfen ob Nummer schon vergeben ist
     const otherIndex = match.schuetzen.findIndex(
       (s, idx) => s[0].rueckennummer === newValue && idx !== schuetzeIndex
     );
 
-    // Wenn die Nummer schon vergeben → Schützen tauschen
+    // Schützen tauschen
     if (otherIndex !== -1) {
       const tmp = match.schuetzen[schuetzeIndex];
       match.schuetzen[schuetzeIndex] = match.schuetzen[otherIndex];
       match.schuetzen[otherIndex] = tmp;
     }
 
-    // Jetzt NEUE Nummer + NEUE MitgliedId in allen 5 Passen setzen
+    // Neue Nummer + MitgliedId übernehmen
     const mitgliedId = match.schuetzen[schuetzeIndex][0].dsbMitgliedId;
 
     for (let j = 0; j < match.schuetzen[schuetzeIndex].length; j++) {
       match.schuetzen[schuetzeIndex][j].rueckennummer = newValue;
       match.schuetzen[schuetzeIndex][j].dsbMitgliedId = mitgliedId;
+    }
+
+    if (matchNr === 1) {
+      this.initialUsed1 = match.schuetzen.map(s => s[0].rueckennummer);
+    } else {
+      this.initialUsed2 = match.schuetzen.map(s => s[0].rueckennummer);
     }
 
     this.dirtyFlag = true;

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
@@ -314,27 +314,16 @@ export class SchusszettelComponent implements OnInit {
 
     const match = this['match' + matchNr];
 
-    // 1. Prüfen ob Nummer schon vergeben ist
-    const otherIndex = match.schuetzen.findIndex(
-      (s, idx) => s[0].rueckennummer === newValue && idx !== schuetzeIndex
-    );
+    const passe0 = match.schuetzen[schuetzeIndex][0];
 
-    if (otherIndex !== -1) {
-      const tmp = match.schuetzen[schuetzeIndex];
-      match.schuetzen[schuetzeIndex] = match.schuetzen[otherIndex];
-      match.schuetzen[otherIndex] = tmp;
-    }
-
-    // 2. korrekte MitgliedId über Map holen
-    const memberMap = (matchNr === 1) ? this.memberMap1 : this.memberMap2;
+    // MitgliedId über Map holen
+    const memberMap = matchNr === 1 ? this.memberMap1 : this.memberMap2;
     const correctMitgliedId = memberMap.get(newValue);
 
-    // 3. rückennummer & dsbMitgliedId im gesamten Schützenblock setzen
-    for (let passe of match.schuetzen[schuetzeIndex]) {
-      passe.rueckennummer = newValue;
-      passe.dsbMitgliedId = correctMitgliedId;
-    }
+    passe0.rueckennummer = newValue;
+    passe0.dsbMitgliedId = correctMitgliedId;
 
+    // Dirty markieren
     this.dirtyFlag = true;
   }
 
@@ -489,11 +478,11 @@ export class SchusszettelComponent implements OnInit {
             this.match2.schuetzen[i][j].lfdNr = j + 1;
           }
 
-          // this.match1.schuetzen[i][j].dsbMitgliedId = this.match1.schuetzen[i][0].dsbMitgliedId;
-          // this.match2.schuetzen[i][j].dsbMitgliedId = this.match2.schuetzen[i][0].dsbMitgliedId;
+          this.match1.schuetzen[i][j].dsbMitgliedId = this.match1.schuetzen[i][0].dsbMitgliedId;
+          this.match2.schuetzen[i][j].dsbMitgliedId = this.match2.schuetzen[i][0].dsbMitgliedId;
 
-          // this.match1.schuetzen[i][j].rueckennummer = this.match1.schuetzen[i][0].rueckennummer;
-          // this.match2.schuetzen[i][j].rueckennummer = this.match2.schuetzen[i][0].rueckennummer;
+          this.match1.schuetzen[i][j].rueckennummer = this.match1.schuetzen[i][0].rueckennummer;
+          this.match2.schuetzen[i][j].rueckennummer = this.match2.schuetzen[i][0].rueckennummer;
         }
       }
 

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
@@ -546,6 +546,9 @@ export class SchusszettelComponent implements OnInit {
     this.match1 = payload[0];
     this.match2 = payload[1];
 
+    this.initialUsed1 = this.match1.schuetzen.map(s => s[0].rueckennummer);
+    this.initialUsed2 = this.match2.schuetzen.map(s => s[0].rueckennummer);
+
     // 2. Falls Schützen fehlen, initialisieren
     if (!this.match1.schuetzen || this.match1.schuetzen.length === 0) {
       this.initSchuetzenMatch1();

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
@@ -68,6 +68,8 @@ export class SchusszettelComponent implements OnInit {
   allowedMitglieder2: number[];
   private initialUsed1: number[] = [];
   private initialUsed2: number[] = [];
+  private memberMap1: Map<number, number>;
+  private memberMap2: Map<number, number>;
 
   // no usages
   matchMannschaft: DsbMannschaftDO;
@@ -312,30 +314,25 @@ export class SchusszettelComponent implements OnInit {
 
     const match = this['match' + matchNr];
 
-    // Prüfen ob Nummer schon vergeben ist
+    // 1. Prüfen ob Nummer schon vergeben ist
     const otherIndex = match.schuetzen.findIndex(
       (s, idx) => s[0].rueckennummer === newValue && idx !== schuetzeIndex
     );
 
-    // Schützen tauschen
     if (otherIndex !== -1) {
       const tmp = match.schuetzen[schuetzeIndex];
       match.schuetzen[schuetzeIndex] = match.schuetzen[otherIndex];
       match.schuetzen[otherIndex] = tmp;
     }
 
-    // Neue Nummer + MitgliedId übernehmen
-    const mitgliedId = match.schuetzen[schuetzeIndex][0].dsbMitgliedId;
+    // 2. korrekte MitgliedId über Map holen
+    const memberMap = (matchNr === 1) ? this.memberMap1 : this.memberMap2;
+    const correctMitgliedId = memberMap.get(newValue);
 
-    for (let j = 0; j < match.schuetzen[schuetzeIndex].length; j++) {
-      match.schuetzen[schuetzeIndex][j].rueckennummer = newValue;
-      match.schuetzen[schuetzeIndex][j].dsbMitgliedId = mitgliedId;
-    }
-
-    if (matchNr === 1) {
-      this.initialUsed1 = match.schuetzen.map(s => s[0].rueckennummer);
-    } else {
-      this.initialUsed2 = match.schuetzen.map(s => s[0].rueckennummer);
+    // 3. rückennummer & dsbMitgliedId im gesamten Schützenblock setzen
+    for (let passe of match.schuetzen[schuetzeIndex]) {
+      passe.rueckennummer = newValue;
+      passe.dsbMitgliedId = correctMitgliedId;
     }
 
     this.dirtyFlag = true;
@@ -492,11 +489,11 @@ export class SchusszettelComponent implements OnInit {
             this.match2.schuetzen[i][j].lfdNr = j + 1;
           }
 
-          this.match1.schuetzen[i][j].dsbMitgliedId = this.match1.schuetzen[i][0].dsbMitgliedId;
-          this.match2.schuetzen[i][j].dsbMitgliedId = this.match2.schuetzen[i][0].dsbMitgliedId;
+          // this.match1.schuetzen[i][j].dsbMitgliedId = this.match1.schuetzen[i][0].dsbMitgliedId;
+          // this.match2.schuetzen[i][j].dsbMitgliedId = this.match2.schuetzen[i][0].dsbMitgliedId;
 
-          this.match1.schuetzen[i][j].rueckennummer = this.match1.schuetzen[i][0].rueckennummer;
-          this.match2.schuetzen[i][j].rueckennummer = this.match2.schuetzen[i][0].rueckennummer;
+          // this.match1.schuetzen[i][j].rueckennummer = this.match1.schuetzen[i][0].rueckennummer;
+          // this.match2.schuetzen[i][j].rueckennummer = this.match2.schuetzen[i][0].rueckennummer;
         }
       }
 
@@ -846,12 +843,21 @@ export class SchusszettelComponent implements OnInit {
       .findAllByTeamId(match.mannschaftId)
       .then(response => {
 
-        const ruecken = response.payload.map(m => m.rueckennummer);
+        const members = response.payload;
+
+        // Map rueckennummer → dsbMitgliedId erstellen
+        const memberMap = new Map<number, number>(
+          members.map(m => [m.rueckennummer, m.dsbMitgliedId])
+        );
+
+        const ruecken = members.map(m => m.rueckennummer);
 
         if (matchNr === 1) {
           this.allowedMitglieder1 = ruecken;
+          this.memberMap1 = memberMap;
         } else {
           this.allowedMitglieder2 = ruecken;
+          this.memberMap2 = memberMap;
         }
       });
   }

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
@@ -309,17 +309,33 @@ export class SchusszettelComponent implements OnInit {
   }
 
   onSchuetzeChangeDropdown(newValue: number, matchNr: number, schuetzeIndex: number) {
+
     const match = this['match' + matchNr];
 
-    // Neue Rückennummer in allen 5 Passen dieses Schützen setzen
+    const otherIndex = match.schuetzen.findIndex(
+      (s, idx) => s[0].rueckennummer === newValue && idx !== schuetzeIndex
+    );
+
+    // Wenn die Nummer schon vergeben → Schützen tauschen
+    if (otherIndex !== -1) {
+      const tmp = match.schuetzen[schuetzeIndex];
+      match.schuetzen[schuetzeIndex] = match.schuetzen[otherIndex];
+      match.schuetzen[otherIndex] = tmp;
+    }
+
+    // Jetzt NEUE Nummer + NEUE MitgliedId in allen 5 Passen setzen
+    const mitgliedId = match.schuetzen[schuetzeIndex][0].dsbMitgliedId;
+
     for (let j = 0; j < match.schuetzen[schuetzeIndex].length; j++) {
       match.schuetzen[schuetzeIndex][j].rueckennummer = newValue;
+      match.schuetzen[schuetzeIndex][j].dsbMitgliedId = mitgliedId;
     }
 
     this.dirtyFlag = true;
   }
 
-  // Rueckennummer fuer Dropdown-Auswahl
+
+  // Rueckennummer Dropdown-Auswahl
   getAvailableRueckennummernMatch1(schuetzeIndex: number): number[] {
     const originallyUsed = this.initialUsed1;
 
@@ -329,7 +345,7 @@ export class SchusszettelComponent implements OnInit {
     );
   }
 
-  // Rueckennummer fuer Dropdown-Auswahl
+  // Rueckennummer Dropdown-Auswahl
   getAvailableRueckennummernMatch2(schuetzeIndex: number): number[] {
     const originallyUsed = this.initialUsed2;
 
@@ -484,8 +500,8 @@ export class SchusszettelComponent implements OnInit {
 
 
           // neu initialisieren, damit passen die noch keine ID haben eine ID vom Backend erhalten
-          this.ngOnInit();
-          // this.reloadUpdatedMatches(data.payload);
+          // this.ngOnInit();
+          this.reloadUpdatedMatches(data.payload);
           this.notificationService.showNotification({
             id: 'NOTIFICATION_SCHUSSZETTEL_ENTSCHIEDEN',
             title: 'WKDURCHFUEHRUNG.SCHUSSZETTEL.NOTIFICATION.GESPEICHERT.TITLE',

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
@@ -319,16 +319,17 @@ export class SchusszettelComponent implements OnInit {
     this.dirtyFlag = true;
   }
 
+  // Rueckennummer fuer Dropdown-Auswahl
   getAvailableRueckennummernMatch1(schuetzeIndex: number): number[] {
     const originallyUsed = this.initialUsed1;
 
     return this.allowedMitglieder1.filter(nr =>
-      nr === originallyUsed[schuetzeIndex] ||      // eigene Nummer bleibt erlaubt
+      nr === originallyUsed[schuetzeIndex] ||      // eigene Nummer erlaubt
       !originallyUsed.includes(nr)                 // alle anderen nur, wenn anfangs frei
     );
   }
 
-
+  // Rueckennummer fuer Dropdown-Auswahl
   getAvailableRueckennummernMatch2(schuetzeIndex: number): number[] {
     const originallyUsed = this.initialUsed2;
 
@@ -525,7 +526,7 @@ export class SchusszettelComponent implements OnInit {
     this.match1 = payload[0];
     this.match2 = payload[1];
 
-    // 2. Falls Schützen fehlen → wie beim Initial-Load initialisieren
+    // 2. Falls Schützen fehlen, initialisieren
     if (!this.match1.schuetzen || this.match1.schuetzen.length === 0) {
       this.initSchuetzenMatch1();
     }
@@ -537,7 +538,7 @@ export class SchusszettelComponent implements OnInit {
     this.initSumSatz();
     this.setPoints();
 
-    // 4. Singlesatz-Punkte neu aufbauen (damit Tabelle korrekt ist)
+    // 4. Singlesatz-Punkte neu aufbauen
     this.match1singlesatzpoints = [...this.match1singlesatzpoints];
     this.match2singlesatzpoints = [...this.match2singlesatzpoints];
   }

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
@@ -61,15 +61,17 @@ export class SchusszettelComponent implements OnInit {
   andererTagVeranstaltung: VeranstaltungDO;
   andererTagAnzahl: number;
 
-  matchMannschaft: DsbMannschaftDO;
-  matchAllPasseMannschaft: PasseDoClass[];
   wettkampf: WettkampfDO;
   veranstaltung: VeranstaltungDO;
   isSaved = false;
-  private lastRueckennummer: number | null = null;
-
+  allowedMitglieder1: number[];
+  allowedMitglieder2: number[];
+  private initialUsed1: number[] = [];
+  private initialUsed2: number[] = [];
 
   // no usages
+  matchMannschaft: DsbMannschaftDO;
+  matchAllPasseMannschaft: PasseDoClass[];
   allPasse: PasseDoClass[] = [];
   allWettkaempfe: WettkampfDO[];
   allVeranstaltungen: VeranstaltungDO[];
@@ -83,8 +85,6 @@ export class SchusszettelComponent implements OnInit {
   anzahlAnTagenMannschaft = new Array<Array<number>>();
   veranstaltungVorherig: VeranstaltungDO;
   veranstaltungGegenwaertig: VeranstaltungDO;
-  allowedMitglieder1: number[];
-  allowedMitglieder2: number[];
 
   constructor(private router: Router,
               private schusszettelService: SchusszettelProviderService,
@@ -148,6 +148,9 @@ export class SchusszettelComponent implements OnInit {
 
           this.match1 = data.payload[0];
           this.match2 = data.payload[1];
+          // Rückennummern laden
+          this.loadAllowedRueckennummern(this.match1, 1);
+          this.loadAllowedRueckennummern(this.match2, 2);
 
           console.log(this.match1, this.match2);
           if (this.match1.matchpunkte !== null && !(this.match1.mannschaftName === 'Platzhalter 1')) {
@@ -205,6 +208,9 @@ export class SchusszettelComponent implements OnInit {
           console.log('match1', this.match1);
           console.log('match2', this.match2);
           let shouldInitSumSatz = true;
+
+          this.initialUsed1 = this.match1.schuetzen.map(s => s[0].rueckennummer);
+          this.initialUsed2 = this.match2.schuetzen.map(s => s[0].rueckennummer);
 
           if (this.match1.schuetzen.length <= 0) {
             this.initSchuetzenMatch1();
@@ -302,106 +308,34 @@ export class SchusszettelComponent implements OnInit {
     this.dirtyFlag = true; // Daten geändert
   }
 
-  rememberOldValue(value: number | null) {
-    this.lastRueckennummer = value;
+  onSchuetzeChangeDropdown(newValue: number, matchNr: number, schuetzeIndex: number) {
+    const match = this['match' + matchNr];
+
+    // Neue Rückennummer in allen 5 Passen dieses Schützen setzen
+    for (let j = 0; j < match.schuetzen[schuetzeIndex].length; j++) {
+      match.schuetzen[schuetzeIndex][j].rueckennummer = newValue;
+    }
+
+    this.dirtyFlag = true;
   }
 
-  async onSchuetzeChange(
-    event: any,
-    matchNr: number,
-    schuetzeIndex: number,
-    satzIndex: number
-  ) {
-    const inputElement: HTMLInputElement = event.target;
-    const newValue = Number(inputElement.value);
+  getAvailableRueckennummernMatch1(schuetzeIndex: number): number[] {
+    const originallyUsed = this.initialUsed1;
 
-    const match = this['match' + matchNr];
-    const mannschaftId = match.mannschaftId;
-
-    const previousValue = this.lastRueckennummer;
-
-    if (newValue == null || newValue === 0) {
-      inputElement.value = previousValue ? String(previousValue) : '';
-      return;
-    }
-
-    // prüfen ob Nummer schon existiert
-    const existsAlready = match.schuetzen.some((schuetze, idx) =>
-      idx !== schuetzeIndex && schuetze[0]?.rueckennummer === newValue
+    return this.allowedMitglieder1.filter(nr =>
+      nr === originallyUsed[schuetzeIndex] ||      // eigene Nummer bleibt erlaubt
+      !originallyUsed.includes(nr)                 // alle anderen nur, wenn anfangs frei
     );
+  }
 
-    if (existsAlready) {
-      this.notificationService.showNotification({
-        id: 'SCHUETZE_DUPLIKAT',
-        title: 'Rückennummer bereits vergeben',
-        description: `Die Rückennummer ${newValue} wird bereits von einem anderen Schützen genutzt.`,
-        severity: NotificationSeverity.ERROR,
-        origin: NotificationOrigin.SYSTEM,
-        type: NotificationType.OK,
-        userAction: NotificationUserAction.ACCEPTED
-      });
 
-      // UI und Model zurücksetzen
-      match.schuetzen[schuetzeIndex][0].rueckennummer = previousValue;
-      inputElement.value = previousValue ? String(previousValue) : '';
+  getAvailableRueckennummernMatch2(schuetzeIndex: number): number[] {
+    const originallyUsed = this.initialUsed2;
 
-      return;
-    }
-
-    try {
-      const response = await this.mannschaftsMitgliedDataProvider
-        .findByTeamIdAndRueckennummer(mannschaftId, newValue);
-
-      const mitglied = response.payload;
-
-      if (!mitglied) {
-        match.schuetzen[schuetzeIndex][0].rueckennummer = previousValue;
-        inputElement.value = previousValue ? String(previousValue) : '';
-
-        this.notificationService.showNotification({
-          id: 'SCHUETZE_NOT_FOUND',
-          title: 'Schütze nicht gefunden',
-          description: `Rückennummer ${newValue} existiert nicht in dieser Mannschaft.`,
-          severity: NotificationSeverity.ERROR,
-          origin: NotificationOrigin.SYSTEM,
-          type: NotificationType.OK,
-          userAction: NotificationUserAction.ACCEPTED
-        });
-
-        return;
-      }
-
-      match.schuetzen[schuetzeIndex][0].rueckennummer = newValue;
-      this.dirtyFlag = true;
-
-    } catch (e) {
-
-      match.schuetzen[schuetzeIndex][0].rueckennummer = previousValue;
-      inputElement.value = previousValue ? String(previousValue) : '';
-
-      if (e?.status === 404) {
-        this.notificationService.showNotification({
-          id: 'SCHUETZE_NOT_FOUND',
-          title: 'Rückennummer nicht gefunden',
-          description: `Rückennummer ${newValue} existiert nicht in dieser Mannschaft.`,
-          severity: NotificationSeverity.ERROR,
-          origin: NotificationOrigin.SYSTEM,
-          type: NotificationType.OK,
-          userAction: NotificationUserAction.ACCEPTED
-        });
-        return;
-      }
-
-      this.notificationService.showNotification({
-        id: 'SCHUETZE_LOOKUP_ERROR',
-        title: 'Fehler beim Laden',
-        description: `Die Rückennummer ${newValue} konnte nicht überprüft werden.`,
-        severity: NotificationSeverity.ERROR,
-        origin: NotificationOrigin.SYSTEM,
-        type: NotificationType.OK,
-        userAction: NotificationUserAction.ACCEPTED
-      });
-    }
+    return this.allowedMitglieder2.filter(nr =>
+      nr === originallyUsed[schuetzeIndex] ||
+      !originallyUsed.includes(nr)
+    );
   }
 
 
@@ -432,29 +366,11 @@ export class SchusszettelComponent implements OnInit {
   }
 
 
-  private getAllMannschaften(): void {
-    this.dsbMannschaftDataProvider.findAll()
-      .then((response: BogenligaResponse<DsbMannschaftDO[]>) => {
-        this.mannschaften = response.payload;
-      });
-  }
-
-
   /**
    * Diese Methode wurde überprüft und wird momentan nicht verwendet. Daher wurde hier die Methode findAll() nicht
    * geändert bzw. angepasst.
    * @private
    */
-
-  private maxMannschaftsId(): number {
-    let maxMid = this.mannschaften[0].id;
-    this.mannschaften.forEach((mannschaft) => {
-      if (mannschaft.id > maxMid) {
-        maxMid = mannschaft.id;
-      }
-    });
-    return maxMid;
-  }
 
   savepopSelberTag() {
     this.popupSelberTag = true;
@@ -565,9 +481,10 @@ export class SchusszettelComponent implements OnInit {
           this.match1 = data.payload[0];
           this.match2 = data.payload[1];
 
+
           // neu initialisieren, damit passen die noch keine ID haben eine ID vom Backend erhalten
-          // this.ngOnInit();
-          this.reloadUpdatedMatches(data.payload);
+          this.ngOnInit();
+          // this.reloadUpdatedMatches(data.payload);
           this.notificationService.showNotification({
             id: 'NOTIFICATION_SCHUSSZETTEL_ENTSCHIEDEN',
             title: 'WKDURCHFUEHRUNG.SCHUSSZETTEL.NOTIFICATION.GESPEICHERT.TITLE',
@@ -900,6 +817,22 @@ export class SchusszettelComponent implements OnInit {
 
   }
 
+  private loadAllowedRueckennummern(match: MatchDOExt, matchNr: number) {
+    this.mannschaftsMitgliedDataProvider
+      .findAllByTeamId(match.mannschaftId)
+      .then(response => {
+
+        const ruecken = response.payload.map(m => m.rueckennummer);
+
+        if (matchNr === 1) {
+          this.allowedMitglieder1 = ruecken;
+        } else {
+          this.allowedMitglieder2 = ruecken;
+        }
+      });
+  }
+
+
   private setKummulativePoints() {
     let kumuluativ1 = 0;
     let kumuluativ2 = 0;
@@ -934,20 +867,6 @@ export class SchusszettelComponent implements OnInit {
       sum += passe.ringzahlPfeil1 + passe.ringzahlPfeil2;
     }
     return sum;
-  }
-
-  // Prüft, ob in einem Match mindestens eine Ringzahl (Pfeil 1 oder 2) enthält.
-  public hasRingzahlen(match: MatchDOExt): boolean {
-    if (!Array.isArray(match?.schuetzen) || match.schuetzen.length === 0) {
-      return false;
-    }
-
-    return match.schuetzen.some(schuetze =>
-      Array.isArray(schuetze) &&
-      schuetze.some(passe =>
-        passe?.ringzahlPfeil1 != null || passe?.ringzahlPfeil2 != null
-      )
-    );
   }
 
   public onButtonDownload(path: string): string {

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/tabindex.directive.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/tabindex.directive.ts
@@ -21,17 +21,6 @@ class IndexGenerator {
 }
 
 /**
- * Incremented each time when used on a schuetzenNr field in the schusszettel-Formular
- */
-class SchuetzenNrIndexGenerator extends IndexGenerator {
-  constructor() {
-    super();
-    this.indices = [1, 2, 3, 34, 35, 36];
-    this.currIdx = 0;
-  }
-}
-
-/**
  * Incremented each time when used on a ringzahl field in the schusszettel-Formular
  */
 class RingzahlIndexGenerator extends IndexGenerator {
@@ -56,7 +45,6 @@ class RingzahlIndexGenerator extends IndexGenerator {
   }
 }
 
-const schuetzenNrIdxGen = new SchuetzenNrIndexGenerator();
 const ringzahlIdxGen = new RingzahlIndexGenerator();
 
 export class TabIndexDirective {
@@ -64,20 +52,6 @@ export class TabIndexDirective {
 
   constructor(el: ElementRef) {
     this.el = el;
-  }
-}
-
-/**
- * Element-directive for schuetzenNr inputs.
- * Sets the next available schuetzenNr tabindex value as HTML-Attribute.
- */
-@Directive({
-  selector: '[blaSchuetzenTabIndexDirective]'
-})
-export class SchuetzenTabIndexDirective extends TabIndexDirective {
-  constructor(el: ElementRef) {
-    super(el);
-    this.el.nativeElement.setAttribute('tabindex', schuetzenNrIdxGen.getNext());
   }
 }
 

--- a/bogenliga/src/app/modules/wkdurchfuehrung/wkdurchfuehrung.module.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/wkdurchfuehrung.module.ts
@@ -9,11 +9,9 @@ import {
   WkdurchfuehrungComponent,
   SchusszettelComponent,
   RingzahlTabIndexDirective,
-  SchuetzenTabIndexDirective,
   TabletEingabeComponent,
   TabletAdminComponent,
   PfeilNumberOnlyDirective,
-  SchuetzeNumberOnlyDirective,
   FehlerpunkteNumberOnlyDirective,
 } from '../wkdurchfuehrung/components';
 
@@ -23,10 +21,13 @@ import {
   TableteingabeGuard,
   TabletadminGuard
 } from '../wkdurchfuehrung/guards';
-import { TeilnemendeManschaftenTabelleComponent } from './components/teilnemende-manschaften-tabelle/teilnemende-manschaften-tabelle.component';
-import { FullscreenComponent } from './components/fullscreen/fullscreen.component';
-import { TabletAdminPopUpComponent } from './components/tablet-admin/tablet-admin-pop-up/tablet-admin-pop-up.component';
+import {
+  TeilnemendeManschaftenTabelleComponent
+} from './components/teilnemende-manschaften-tabelle/teilnemende-manschaften-tabelle.component';
+import {FullscreenComponent} from './components/fullscreen/fullscreen.component';
+import {TabletAdminPopUpComponent} from './components/tablet-admin/tablet-admin-pop-up/tablet-admin-pop-up.component';
 import {QRCodeModule} from 'angularx-qrcode';
+
 @NgModule({
   imports: [
     CommonModule,
@@ -39,17 +40,15 @@ import {QRCodeModule} from 'angularx-qrcode';
     WkdurchfuehrungComponent,
     SchusszettelComponent,
     PfeilNumberOnlyDirective,
-    SchuetzeNumberOnlyDirective,
     FehlerpunkteNumberOnlyDirective,
     RingzahlTabIndexDirective,
-    SchuetzenTabIndexDirective,
     TabletEingabeComponent,
     TabletAdminComponent,
     TeilnemendeManschaftenTabelleComponent,
     FullscreenComponent,
     TabletAdminPopUpComponent,
   ],
-  providers:    [
+  providers: [
     WkdurchfuehrungGuard,
     SchusszettelGuard,
     TableteingabeGuard,


### PR DESCRIPTION
Die Auswahl der Rückennummer in WKDurchführung/Schusszettel wurde vereinfacht und robuster gemacht. Statt Freitext-Input-Feld gibt es nun ein Dropdown, das beim ngOnInit automatisch nur gültige Rückennummern lädt und in zwei Arrays speichert (Match1, Match2). Dadurch entfällt Validierungslogik und mögliche Fehleingaben im Freitextfeld, bessere UI, weniger Pop-Ups.

Änderungen:
- Schützenauswahl als Dropdown statt Input-Feld, weniger Logik & geringeres Fehlerpotenzial
- Entfernt: TabIndexDirectives, NumberDirectives
- Entfernt: rememberOldValue(), onSchuetzeChange()
- Hinzugefügt: getAvailableRueckennummernMatch1(), getAvailableRueckennummernMatch2()
- Nur noch gültige Rückennummern im Dropdown verfügbar; keine ungültigen/duplizierten Eingaben mehr möglich