### PR TITLE
Ligaübersicht verfügt jetzt über einen Expand/Collapse-All Button

### DIFF
--- a/bogenliga/src/app/modules/liga-overview/components/liga-overview/liga-overview.component.html
+++ b/bogenliga/src/app/modules/liga-overview/components/liga-overview/liga-overview.component.html
@@ -21,6 +21,22 @@
 
             <ng-template #treeContent>
               <ng-container *ngIf="treeNodes.length > 0; else treeStateMessage">
+                <div class="liga-tree-actions">
+                  <button
+                    type="button"
+                    class="btn btn-sm btn-outline-secondary"
+                    (click)="onToggleTreeExpansion()"
+                    [attr.aria-pressed]="isTreeFullyExpanded"
+                    [attr.title]="(isTreeFullyExpanded ? 'LIGAUEBERSICHT.TREE.COLLAPSE_ALL' : 'LIGAUEBERSICHT.TREE.EXPAND_ALL') | translate">
+                    <i
+                      class="fa"
+                      [ngClass]="isTreeFullyExpanded ? 'fa-compress' : 'fa-expand'"
+                      aria-hidden="true"></i>
+                    <span class="ms-1">
+                      {{ isTreeFullyExpanded ? ('LIGAUEBERSICHT.TREE.COLLAPSE_ALL' | translate) : ('LIGAUEBERSICHT.TREE.EXPAND_ALL' | translate) }}
+                    </span>
+                  </button>
+                </div>
                 <div class="liga-tree-wrapper">
                   <bla-league-tree
                     [nodes]="treeNodes"

--- a/bogenliga/src/app/modules/liga-overview/components/liga-overview/liga-overview.component.scss
+++ b/bogenliga/src/app/modules/liga-overview/components/liga-overview/liga-overview.component.scss
@@ -11,6 +11,14 @@
   margin-top: 32px;
 }
 
+.liga-tree-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
 .liga-tree-wrapper {
   border: 1px solid rgba(0, 0, 0, 0.08);
   border-radius: 8px;
@@ -25,4 +33,10 @@
   gap: 0.5rem;
   font-size: 0.95rem;
   margin-top: 16px;
+}
+
+@media (max-width: 768px) {
+  .liga-tree-actions {
+    justify-content: flex-start;
+  }
 }

--- a/bogenliga/src/app/modules/liga-overview/components/liga-overview/liga-overview.component.ts
+++ b/bogenliga/src/app/modules/liga-overview/components/liga-overview/liga-overview.component.ts
@@ -48,6 +48,12 @@ export class LigaOverviewComponent implements OnInit, OnDestroy {
   selectedLigaId: number | null = null;
 
   /**
+   * Merker, ob der Baum zuletzt vollständig ausgeklappt wurde.
+   * Dient ausschließlich zur Beschriftung/Funktion des Toggle-Buttons.
+   */
+  isTreeFullyExpanded = false;
+
+  /**
    * Übersetzungsschlüssel für Statusmeldungen.
    */
   statusMessageKey: string | null = null;
@@ -103,12 +109,36 @@ export class LigaOverviewComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Globaler Button: Baum vollständig ein-/ausklappen.
+   */
+  onToggleTreeExpansion(): void {
+    const nextExpanded = !this.isTreeFullyExpanded;
+
+    try {
+      this.analytics.track('tree_expand_all_toggle', {
+        nextState: nextExpanded ? 'expanded' : 'collapsed'
+      });
+    } catch {
+      // Analytics-Fehler ignorieren, UI soll nicht beeinflusst werden
+    }
+
+    if (nextExpanded) {
+      this.treeComponent?.expandAll();
+    } else {
+      this.treeComponent?.collapseAll();
+    }
+
+    this.isTreeFullyExpanded = nextExpanded;
+  }
+
+  /**
    * Lädt die Liga-Hierarchie und bereitet den Tree vor.
    */
   private loadHierarchy(): void {
     this.isLoading = true;
     this.hierarchyResult = null;
     this.statusMessageKey = null;
+    this.isTreeFullyExpanded = false;
 
     const stop = this.analytics.startTimer('api_liga_hierarchie');
 

--- a/bogenliga/src/app/modules/liga-overview/components/tree/tree.component.ts
+++ b/bogenliga/src/app/modules/liga-overview/components/tree/tree.component.ts
@@ -234,6 +234,47 @@ export class TreeComponent implements OnChanges, AfterViewInit, OnDestroy {
   }
 
   /**
+   * Expandiert alle Knoten im Baum.
+   * Wird z. B. vom Global-Expand-Button in der Ligaübersicht verwendet.
+   */
+  expandAll(): void {
+    if (this.nodeById.size === 0) {
+      return;
+    }
+
+    let mutated = false;
+    for (const id of this.nodeById.keys()) {
+      if (!this.expandedIds.has(id)) {
+        this.expandedIds.add(id);
+        mutated = true;
+      }
+    }
+
+    if (mutated) {
+      this.expandedIds = new Set(this.expandedIds);
+      this.updateVisibleNodes();
+      this.ensureFocusableNode();
+      this.cdr.markForCheck();
+    }
+  }
+
+  /**
+   * Klappt alle Knoten ein, so dass nur die Wurzelebene sichtbar bleibt.
+   * Wird z. B. vom Global-Collapse-Button in der Ligaübersicht verwendet.
+   */
+  collapseAll(): void {
+    if (this.expandedIds.size === 0) {
+      return;
+    }
+
+    this.expandedIds.clear();
+    this.expandedIds = new Set<NodeId>();
+    this.updateVisibleNodes();
+    this.ensureFocusableNode();
+    this.cdr.markForCheck();
+  }
+
+  /**
    * Expandiert den Pfad zu einem Knoten und markiert ihn.
    * 
    * Findet alle Eltern-Knoten bis zur Wurzel und expandiert sie,

--- a/bogenliga/src/assets/i18n/de.json
+++ b/bogenliga/src/assets/i18n/de.json
@@ -2026,7 +2026,9 @@
     "TREE": {
       "TITLE": "Liga-Hierarchie",
       "EXPAND": "Knoten ausklappen",
-      "COLLAPSE": "Knoten einklappen"
+      "COLLAPSE": "Knoten einklappen",
+      "EXPAND_ALL": "Alle Knoten ausklappen",
+      "COLLAPSE_ALL": "Alle Knoten einklappen"
     },
     "DEEPLINK": {
       "INVALID_ID": "Die angegebene Liga-ID ist ungültig.",

--- a/bogenliga/src/assets/i18n/en.json
+++ b/bogenliga/src/assets/i18n/en.json
@@ -2017,7 +2017,9 @@
     "TREE": {
       "TITLE": "League hierarchy",
       "EXPAND": "Expand node",
-      "COLLAPSE": "Collapse node"
+      "COLLAPSE": "Collapse node",
+      "EXPAND_ALL": "Expand all nodes",
+      "COLLAPSE_ALL": "Collapse all nodes"
     },
     "DEEPLINK": {
       "INVALID_ID": "The specified league ID is invalid.",


### PR DESCRIPTION
LAYOUT-002: Globaler Expand/Collapse-All Button für Liga-Baum https://gitlab.gras-it.de/hsrt/swt2/-/issues/2007
ermöglichen des vollständige Auf- und Zuklappen des Baums  mit einem Klick