### PR TITLE
#2009

### DIFF
--- a/bogenliga/src/app/modules/liga-overview/components/tree/tree-node.component.html
+++ b/bogenliga/src/app/modules/liga-overview/components/tree/tree-node.component.html
@@ -12,7 +12,9 @@
     (click)="onToggleClick($event)"
     [attr.aria-label]="(expanded ? 'LIGAUEBERSICHT.TREE.COLLAPSE' : 'LIGAUEBERSICHT.TREE.EXPAND') | translate"
     tabindex="-1">
-    <span class="bla-league-tree__toggle-icon" aria-hidden="true"></span>
+    <span class="bla-league-tree__toggle-icon" 
+          [class.bla-league-tree__toggle-icon--expanded]="expanded" 
+          aria-hidden="true"></span>
   </button>
   <span *ngIf="!hasChildren" class="bla-league-tree__toggle-placeholder" aria-hidden="true"></span>
   <span class="bla-league-tree__label">

--- a/bogenliga/src/app/modules/liga-overview/components/tree/tree-node.component.scss
+++ b/bogenliga/src/app/modules/liga-overview/components/tree/tree-node.component.scss
@@ -51,6 +51,7 @@
 
 .bla-league-tree__item-row {
   position: relative;
+  z-index: 1; /* Über den Verbindungslinien */
   display: flex;
   align-items: center;
   gap: 0.4rem;
@@ -59,14 +60,15 @@
   cursor: pointer;
   border-radius: var(--bla-tree-border-radius, 6px);
   box-shadow: var(--bla-tree-card-shadow);
-  border: 1px solid var(--bla-tree-level-default-border);
-  background: var(--bla-tree-level-default-bg);
-  color: var(--bla-tree-level-default-foreground, #1d2533);
+  border: 2px solid var(--bla-tree-level-default-border, #888888);
+  background: var(--bla-tree-level-default-bg, #FFFFFF);
+  color: var(--bla-tree-level-default-foreground, #2A2A2A);
   transition: box-shadow 160ms ease, transform 160ms ease;
   width: auto;
   min-width: 150px;
   max-width: 220px;
   margin: 0 auto;
+  isolation: isolate; /* Stacking Context für z-index */
 }
 
 .bla-league-tree__item-row:hover {
@@ -75,8 +77,8 @@
 }
 
 .bla-league-tree__item--selected .bla-league-tree__item-row {
-  background: var(--bla-tree-selected-bg);
-  border-color: #487AF5;
+  background: var(--bla-tree-selected-bg, rgba(72, 122, 245, 0.08));
+  /* Border-Farbe bleibt erhalten, nur zusätzlicher Focus-Ring */
   box-shadow: 0 0 0 3px rgba(72, 122, 245, 0.35), var(--bla-tree-card-shadow);
 }
 
@@ -103,14 +105,14 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: rgba(255, 255, 255, 0.18);
-  color: inherit;
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--bla-tree-level-default-icon-color, #888888);
   cursor: pointer;
   transition: background-color 120ms ease;
 }
 
 .bla-league-tree__toggle:hover {
-  background-color: rgba(255, 255, 255, 0.32);
+  background-color: rgba(0, 0, 0, 0.1);
 }
 
 .bla-league-tree__toggle:focus {
@@ -131,6 +133,7 @@
   width: 10px;
   height: 10px;
   transition: transform 200ms ease;
+  color: inherit; /* Übernimmt die Icon-Farbe vom Toggle-Button */
 }
 
 /* Chevron als CSS-Pfeil - Default: Zeigt nach rechts (▶) */
@@ -185,43 +188,87 @@
   transform: translateX(-50%);
 }
 
-/* Level theming - Graustufen gemäß Styleguide UI-STYLE-004 (einheitlich weiße Schrift) */
+/* Level theming - Bogenscheiben-Farben: Weiße Cards mit farbiger Umrandung */
 :host([data-level="0"]) .bla-league-tree__item-row {
   background: var(--bla-tree-level-0-bg);
-  border-color: var(--bla-tree-level-0-border);
-  color: var(--bla-tree-level-0-color, #FFFFFF);
+  border: 2px solid var(--bla-tree-level-0-border);
+  color: var(--bla-tree-level-0-color, #2A2A2A);
+}
+
+:host([data-level="0"]) .bla-league-tree__toggle {
+  color: var(--bla-tree-level-0-icon-color, #FFCC34);
 }
 
 :host([data-level="1"]) .bla-league-tree__item-row {
   background: var(--bla-tree-level-1-bg);
-  border-color: var(--bla-tree-level-1-border);
-  color: var(--bla-tree-level-1-color, #FFFFFF);
+  border: 2px solid var(--bla-tree-level-1-border);
+  color: var(--bla-tree-level-1-color, #2A2A2A);
+}
+
+:host([data-level="1"]) .bla-league-tree__toggle {
+  color: var(--bla-tree-level-1-icon-color, #FFE066);
 }
 
 :host([data-level="2"]) .bla-league-tree__item-row {
   background: var(--bla-tree-level-2-bg);
-  border-color: var(--bla-tree-level-2-border);
-  color: var(--bla-tree-level-2-color, #FFFFFF);
+  border: 2px solid var(--bla-tree-level-2-border);
+  color: var(--bla-tree-level-2-color, #2A2A2A);
+}
+
+:host([data-level="2"]) .bla-league-tree__toggle {
+  color: var(--bla-tree-level-2-icon-color, #F40E0E);
 }
 
 :host([data-level="3"]) .bla-league-tree__item-row {
   background: var(--bla-tree-level-3-bg);
-  border-color: var(--bla-tree-level-3-border);
-  color: var(--bla-tree-level-3-color, #FFFFFF);
+  border: 2px solid var(--bla-tree-level-3-border);
+  color: var(--bla-tree-level-3-color, #2A2A2A);
+}
+
+:host([data-level="3"]) .bla-league-tree__toggle {
+  color: var(--bla-tree-level-3-icon-color, #F85C5C);
 }
 
 :host([data-level="4"]) .bla-league-tree__item-row {
   background: var(--bla-tree-level-4-bg);
-  border-color: var(--bla-tree-level-4-border);
-  color: var(--bla-tree-level-4-color, #FFFFFF);
+  border: 2px solid var(--bla-tree-level-4-border);
+  color: var(--bla-tree-level-4-color, #2A2A2A);
 }
 
-:host([data-level="5"]) .bla-league-tree__item-row,
-:host([data-level="6"]) .bla-league-tree__item-row,
-:host([data-level="7"]) .bla-league-tree__item-row {
+:host([data-level="4"]) .bla-league-tree__toggle {
+  color: var(--bla-tree-level-4-icon-color, #487AF5);
+}
+
+:host([data-level="5"]) .bla-league-tree__item-row {
+  background: var(--bla-tree-level-5-bg);
+  border: 2px solid var(--bla-tree-level-5-border);
+  color: var(--bla-tree-level-5-color, #2A2A2A);
+}
+
+:host([data-level="5"]) .bla-league-tree__toggle {
+  color: var(--bla-tree-level-5-icon-color, #7BA3F7);
+}
+
+:host([data-level="6"]) .bla-league-tree__item-row {
+  background: var(--bla-tree-level-6-bg);
+  border: 2px solid var(--bla-tree-level-6-border);
+  color: var(--bla-tree-level-6-color, #2A2A2A);
+}
+
+:host([data-level="6"]) .bla-league-tree__toggle {
+  color: var(--bla-tree-level-6-icon-color, #2A2A2A);
+}
+
+:host([data-level="7"]) .bla-league-tree__item-row,
+:host([data-level="8"]) .bla-league-tree__item-row {
   background: var(--bla-tree-level-default-bg);
-  border-color: var(--bla-tree-level-default-border);
-  color: var(--bla-tree-level-default-foreground, #FFFFFF);
+  border: 2px solid var(--bla-tree-level-default-border);
+  color: var(--bla-tree-level-default-foreground, #2A2A2A);
+}
+
+:host([data-level="7"]) .bla-league-tree__toggle,
+:host([data-level="8"]) .bla-league-tree__toggle {
+  color: var(--bla-tree-level-default-icon-color, #888888);
 }
 
 @media (max-width: 992px) {

--- a/bogenliga/src/app/modules/liga-overview/components/tree/tree-node.component.scss
+++ b/bogenliga/src/app/modules/liga-overview/components/tree/tree-node.component.scss
@@ -76,12 +76,12 @@
 
 .bla-league-tree__item--selected .bla-league-tree__item-row {
   background: var(--bla-tree-selected-bg);
-  border-color: #2c7be5;
-  box-shadow: 0 0 0 3px rgba(44, 123, 229, 0.35), var(--bla-tree-card-shadow);
+  border-color: #487AF5;
+  box-shadow: 0 0 0 3px rgba(72, 122, 245, 0.35), var(--bla-tree-card-shadow);
 }
 
 .bla-league-tree__item--focused .bla-league-tree__item-row {
-  box-shadow: 0 0 0 3px rgba(44, 123, 229, 0.35), var(--bla-tree-card-shadow);
+  box-shadow: 0 0 0 3px rgba(72, 122, 245, 0.35), var(--bla-tree-card-shadow);
 }
 
 .bla-league-tree__label {
@@ -125,38 +125,31 @@
   flex: 0 0 28px;
 }
 
+/* Chevron-Icon gemäß Styleguide UI-STYLE-004 */
 .bla-league-tree__toggle-icon {
   position: relative;
-  width: 12px;
-  height: 12px;
+  width: 10px;
+  height: 10px;
+  transition: transform 200ms ease;
 }
 
-.bla-league-tree__toggle-icon::before,
-.bla-league-tree__toggle-icon::after {
+/* Chevron als CSS-Pfeil - Default: Zeigt nach rechts (▶) */
+.bla-league-tree__toggle-icon::before {
   content: '';
   position: absolute;
-  background-color: currentColor;
-  transition: transform 140ms ease;
-}
-
-.bla-league-tree__toggle-icon::before {
   top: 50%;
-  left: 0;
-  right: 0;
-  height: 2px;
-  transform: translateY(-50%);
-}
-
-.bla-league-tree__toggle-icon::after {
   left: 50%;
-  top: 0;
-  bottom: 0;
-  width: 2px;
-  transform: translateX(-50%);
+  width: 6px;
+  height: 6px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: translate(-60%, -50%) rotate(-45deg);
+  transition: transform 200ms ease;
 }
 
-.bla-league-tree__item--expanded .bla-league-tree__toggle-icon::after {
-  transform: translateX(-50%) scaleY(0);
+/* Ausgeklappt: Pfeil zeigt nach unten (▼) - Direkte Klasse auf dem Element */
+.bla-league-tree__toggle-icon--expanded::before {
+  transform: translate(-50%, -70%) rotate(45deg);
 }
 
 .bla-league-tree__item-row[data-has-children="false"] .bla-league-tree__toggle {
@@ -192,35 +185,35 @@
   transform: translateX(-50%);
 }
 
-/* Level theming */
+/* Level theming - Graustufen gemäß Styleguide UI-STYLE-004 (einheitlich weiße Schrift) */
 :host([data-level="0"]) .bla-league-tree__item-row {
   background: var(--bla-tree-level-0-bg);
   border-color: var(--bla-tree-level-0-border);
-  color: #ffffff;
+  color: var(--bla-tree-level-0-color, #FFFFFF);
 }
 
 :host([data-level="1"]) .bla-league-tree__item-row {
   background: var(--bla-tree-level-1-bg);
   border-color: var(--bla-tree-level-1-border);
-  color: #1f1300;
+  color: var(--bla-tree-level-1-color, #FFFFFF);
 }
 
 :host([data-level="2"]) .bla-league-tree__item-row {
   background: var(--bla-tree-level-2-bg);
   border-color: var(--bla-tree-level-2-border);
-  color: #f0f4ff;
+  color: var(--bla-tree-level-2-color, #FFFFFF);
 }
 
 :host([data-level="3"]) .bla-league-tree__item-row {
   background: var(--bla-tree-level-3-bg);
   border-color: var(--bla-tree-level-3-border);
-  color: #f6f7fb;
+  color: var(--bla-tree-level-3-color, #FFFFFF);
 }
 
 :host([data-level="4"]) .bla-league-tree__item-row {
   background: var(--bla-tree-level-4-bg);
   border-color: var(--bla-tree-level-4-border);
-  color: #f8f9fb;
+  color: var(--bla-tree-level-4-color, #FFFFFF);
 }
 
 :host([data-level="5"]) .bla-league-tree__item-row,
@@ -228,7 +221,7 @@
 :host([data-level="7"]) .bla-league-tree__item-row {
   background: var(--bla-tree-level-default-bg);
   border-color: var(--bla-tree-level-default-border);
-  color: #1d2533;
+  color: var(--bla-tree-level-default-foreground, #FFFFFF);
 }
 
 @media (max-width: 992px) {

--- a/bogenliga/src/app/modules/liga-overview/components/tree/tree.component.scss
+++ b/bogenliga/src/app/modules/liga-overview/components/tree/tree.component.scss
@@ -12,25 +12,47 @@
   --bla-tree-node-gap: 16px;
   --bla-tree-branch-length: 24px;
   --bla-tree-branch-color: #d8dde8;
-  /* Graustufen gemäß Styleguide UI-STYLE-004 - Maximale Unterscheidbarkeit */
-  --bla-tree-level-0-bg: #0D0D0D;
-  --bla-tree-level-0-border: #000000;
-  --bla-tree-level-0-color: #FFFFFF;
-  --bla-tree-level-1-bg: #2E2E2E;
-  --bla-tree-level-1-border: #1E1E1E;
-  --bla-tree-level-1-color: #FFFFFF;
-  --bla-tree-level-2-bg: #4A4A4A;
-  --bla-tree-level-2-border: #3A3A3A;
-  --bla-tree-level-2-color: #FFFFFF;
-  --bla-tree-level-3-bg: #616161;
-  --bla-tree-level-3-border: #515151;
-  --bla-tree-level-3-color: #FFFFFF;
-  --bla-tree-level-4-bg: #757575;
-  --bla-tree-level-4-border: #656565;
-  --bla-tree-level-4-color: #FFFFFF;
-  --bla-tree-level-default-bg: #757575;
-  --bla-tree-level-default-border: #656565;
-  --bla-tree-level-default-foreground: #FFFFFF;
+  /* Bogenscheiben-Farben: Gelb, Rot, Blau, Schwarz, Weiß - Weiße Cards mit farbiger Umrandung */
+  /* Level 0: Gelb kräftig */
+  --bla-tree-level-0-bg: #FFFFFF;
+  --bla-tree-level-0-border: #FFCC34;
+  --bla-tree-level-0-color: #2A2A2A;
+  --bla-tree-level-0-icon-color: #FFCC34;
+  /* Level 1: Gelb leichter */
+  --bla-tree-level-1-bg: #FFFFFF;
+  --bla-tree-level-1-border: #FFE066;
+  --bla-tree-level-1-color: #2A2A2A;
+  --bla-tree-level-1-icon-color: #FFE066;
+  /* Level 2: Rot kräftig */
+  --bla-tree-level-2-bg: #FFFFFF;
+  --bla-tree-level-2-border: #F40E0E;
+  --bla-tree-level-2-color: #2A2A2A;
+  --bla-tree-level-2-icon-color: #F40E0E;
+  /* Level 3: Rot leichter */
+  --bla-tree-level-3-bg: #FFFFFF;
+  --bla-tree-level-3-border: #F85C5C;
+  --bla-tree-level-3-color: #2A2A2A;
+  --bla-tree-level-3-icon-color: #F85C5C;
+  /* Level 4: Blau kräftig */
+  --bla-tree-level-4-bg: #FFFFFF;
+  --bla-tree-level-4-border: #487AF5;
+  --bla-tree-level-4-color: #2A2A2A;
+  --bla-tree-level-4-icon-color: #487AF5;
+  /* Level 5: Blau leichter */
+  --bla-tree-level-5-bg: #FFFFFF;
+  --bla-tree-level-5-border: #7BA3F7;
+  --bla-tree-level-5-color: #2A2A2A;
+  --bla-tree-level-5-icon-color: #7BA3F7;
+  /* Level 6: Schwarz */
+  --bla-tree-level-6-bg: #FFFFFF;
+  --bla-tree-level-6-border: #2A2A2A;
+  --bla-tree-level-6-color: #2A2A2A;
+  --bla-tree-level-6-icon-color: #2A2A2A;
+  /* Level 7+: Grau (Default) */
+  --bla-tree-level-default-bg: #FFFFFF;
+  --bla-tree-level-default-border: #888888;
+  --bla-tree-level-default-foreground: #2A2A2A;
+  --bla-tree-level-default-icon-color: #888888;
   --bla-tree-card-shadow: 0 4px 10px rgba(18, 33, 54, 0.1);
 
   font-size: 13px;

--- a/bogenliga/src/app/modules/liga-overview/components/tree/tree.component.scss
+++ b/bogenliga/src/app/modules/liga-overview/components/tree/tree.component.scss
@@ -4,27 +4,33 @@
 }
 
 .bla-league-tree {
-  --bla-tree-focus-ring: 2px solid var(--bla-color-focus, #2c7be5);
-  --bla-tree-hover-bg: rgba(44, 123, 229, 0.08);
-  --bla-tree-selected-bg: rgba(44, 123, 229, 0.16);
+  --bla-tree-focus-ring: 2px solid var(--bla-color-focus, #487AF5);
+  --bla-tree-hover-bg: rgba(72, 122, 245, 0.08);
+  --bla-tree-selected-bg: rgba(72, 122, 245, 0.16);
   --bla-tree-border-radius: 6px;
   --bla-tree-row-height: 48px;
   --bla-tree-node-gap: 16px;
   --bla-tree-branch-length: 24px;
   --bla-tree-branch-color: #d8dde8;
-  --bla-tree-level-0-bg: #d62828;
-  --bla-tree-level-0-border: #b71f21;
-  --bla-tree-level-1-bg: #f77f00;
-  --bla-tree-level-1-border: #d26a00;
-  --bla-tree-level-2-bg: #1d3557;
-  --bla-tree-level-2-border: #14253d;
-  --bla-tree-level-3-bg: #2b2d42;
-  --bla-tree-level-3-border: #1e1f30;
-  --bla-tree-level-4-bg: #6c757d;
-  --bla-tree-level-4-border: #545c63;
-  --bla-tree-level-default-bg: #ffffff;
-  --bla-tree-level-default-border: #d1d6e0;
-  --bla-tree-level-default-foreground: #1d2533;
+  /* Graustufen gemäß Styleguide UI-STYLE-004 - Maximale Unterscheidbarkeit */
+  --bla-tree-level-0-bg: #0D0D0D;
+  --bla-tree-level-0-border: #000000;
+  --bla-tree-level-0-color: #FFFFFF;
+  --bla-tree-level-1-bg: #2E2E2E;
+  --bla-tree-level-1-border: #1E1E1E;
+  --bla-tree-level-1-color: #FFFFFF;
+  --bla-tree-level-2-bg: #4A4A4A;
+  --bla-tree-level-2-border: #3A3A3A;
+  --bla-tree-level-2-color: #FFFFFF;
+  --bla-tree-level-3-bg: #616161;
+  --bla-tree-level-3-border: #515151;
+  --bla-tree-level-3-color: #FFFFFF;
+  --bla-tree-level-4-bg: #757575;
+  --bla-tree-level-4-border: #656565;
+  --bla-tree-level-4-color: #FFFFFF;
+  --bla-tree-level-default-bg: #757575;
+  --bla-tree-level-default-border: #656565;
+  --bla-tree-level-default-foreground: #FFFFFF;
   --bla-tree-card-shadow: 0 4px 10px rgba(18, 33, 54, 0.1);
 
   font-size: 13px;


### PR DESCRIPTION
https://gitlab.gras-it.de/hsrt/swt2/-/issues/2010


Nach dem Styleguide-Update für die Liga-Hierarchie (UI-STYLE-004) sowie den präzisierten Button-/Card-Vorschriften muss die bestehende Umsetzung der Ligaübersicht (Tree, Cards, Aktionen) angepasst werden. Ziel ist, alle relevanten Komponenten (Liga-Cards, Action-Buttons, States, Icons) konsistent an die verhandelten Styleguide-Regeln anzupassen und Alt-Styling (provisorische Buttons, nicht-konforme Farben/Abstände) zu bereinigen.

Mit diesem Pull Request wird das beschriebene Ziel umgesetzt. Styleguide und Implementierung sind nun konsistent zueinander.