### PR TITLE
Liganame aus den "Zu den Wettkampfergebnissen"-Buttons entfernt, dazu…

### DIFF
--- a/bogenliga/src/app/modules/home/components/home/home.component.html
+++ b/bogenliga/src/app/modules/home/components/home/home.component.html
@@ -74,7 +74,6 @@
               [iconClass]="'th-list'"
               (onClick)="ligatabelleLinking()">
               {{ 'WETTKAEMPFE.LIGATABELLE.LINKDESCRIPTION' | translate }}
-              {{ veranstaltung?.name }}
             </bla-actionbutton>
           </div>
         </bla-veranstaltungen-button>
@@ -122,7 +121,6 @@
             [iconClass]="'th-list'"
             (onClick)="ligatabelleLinking()">
             {{ 'WETTKAEMPFE.LIGATABELLE.LINKDESCRIPTION' | translate }}
-            {{ veranstaltung?.name }}
           </bla-actionbutton>
 
           <bla-actionbutton

--- a/bogenliga/src/app/modules/ligatabelle/components/ligatabelle/ligatabelle.component.html
+++ b/bogenliga/src/app/modules/ligatabelle/components/ligatabelle/ligatabelle.component.html
@@ -79,14 +79,13 @@
 
         <!-- Button -->
         <div id="Button">
-          <!-- Button - Zu den Wettkampfergebnissen {Name der Liga} -->
+          <!-- Button - Zu den Wettkampfergebnissen -->
           <bla-actionbutton
             [id]="'regionSaveButton'"
             [color]= "ActionButtonColors.SUCCESS"
             [iconClass]="'th-list'"
             (onClick)="ligatabelleLinking()">
             {{ 'WETTKAEMPFE.LIGATABELLE.LINKDESCRIPTION' | translate }}
-            {{ selectedVeranstaltungName}}
           </bla-actionbutton>
 
 


### PR DESCRIPTION
… einfach den zusätzlichen String beim Aufruf der Buttonkomponenten entfernt.

https://gitlab.gras-it.de/hsrt/swt2/-/issues/2018