### PR TITLE
fix(#2000 #2013): doppelte Rückennummern & Schützen-Tausch

### DIFF
--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
@@ -332,13 +332,10 @@ export class SchusszettelComponent implements OnInit {
     if (!this.allowedMitglieder1) {
       return [];
     }
-
-    // aktuell ausgewählte Nummern
     const used = this.match1.schuetzen
       .map(s => s[0].rueckennummer)
       .filter(nr => nr != null);
 
-    // eigene Nummer behalten
     const own = this.match1.schuetzen[schuetzeIndex][0].rueckennummer;
 
     return this.allowedMitglieder1.filter(nr =>
@@ -346,17 +343,18 @@ export class SchusszettelComponent implements OnInit {
     );
   }
 
-
-  // Rueckennummer Dropdown-Auswahl
   getAvailableRueckennummernMatch2(schuetzeIndex: number): number[] {
-    if (!this.allowedMitglieder2 || !this.initialUsed2) {
+    if (!this.allowedMitglieder2) {
       return [];
     }
-    const originallyUsed = this.initialUsed2;
+    const used = this.match2.schuetzen
+      .map(s => s[0].rueckennummer)
+      .filter(nr => nr != null);
+
+    const own = this.match2.schuetzen[schuetzeIndex][0].rueckennummer;
 
     return this.allowedMitglieder2.filter(nr =>
-      nr === originallyUsed[schuetzeIndex] ||
-      !originallyUsed.includes(nr)
+      nr === own || !used.includes(nr)
     );
   }
 

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/schusszettel/schusszettel.component.ts
@@ -328,18 +328,24 @@ export class SchusszettelComponent implements OnInit {
   }
 
 
-  // Rueckennummer Dropdown-Auswahl
   getAvailableRueckennummernMatch1(schuetzeIndex: number): number[] {
-    if (!this.allowedMitglieder1 || !this.initialUsed1) {
+    if (!this.allowedMitglieder1) {
       return [];
     }
-    const originallyUsed = this.initialUsed1;
+
+    // aktuell ausgewählte Nummern
+    const used = this.match1.schuetzen
+      .map(s => s[0].rueckennummer)
+      .filter(nr => nr != null);
+
+    // eigene Nummer behalten
+    const own = this.match1.schuetzen[schuetzeIndex][0].rueckennummer;
 
     return this.allowedMitglieder1.filter(nr =>
-      nr === originallyUsed[schuetzeIndex] ||      // eigene Nummer erlaubt
-      !originallyUsed.includes(nr)                 // alle anderen nur, wenn anfangs frei
+      nr === own || !used.includes(nr)
     );
   }
+
 
   // Rueckennummer Dropdown-Auswahl
   getAvailableRueckennummernMatch2(schuetzeIndex: number): number[] {
@@ -477,12 +483,10 @@ export class SchusszettelComponent implements OnInit {
       // kopieren in jede Passe, damit Datenanlage möglich --> Schüsselwert für DB
       for (let i = 0; i < 3; i++) {
         for (let j = 1; j < 5; j++) {
-          if (this.match1.schuetzen[i][j].lfdNr <= 1) {
-            this.match1.schuetzen[i][j].lfdNr = j + 1;
-          }
-          if (this.match2.schuetzen[i][j].lfdNr <= 1) {
-            this.match2.schuetzen[i][j].lfdNr = j + 1;
-          }
+
+          this.match1.schuetzen[i][j].lfdNr = j + 1;
+          this.match2.schuetzen[i][j].lfdNr = j + 1;
+
 
           this.match1.schuetzen[i][j].dsbMitgliedId = this.match1.schuetzen[i][0].dsbMitgliedId;
           this.match2.schuetzen[i][j].dsbMitgliedId = this.match2.schuetzen[i][0].dsbMitgliedId;


### PR DESCRIPTION
fix(#2000 und #2013): doppelte Rückennummern verhindern & Schützen-Tausch korrigieren

- Dropdown filtert jetzt bereits gewählte Rückennummern (sowohl aktiv gewählte als auch neu gewählte)
- DB-Fehler bei Schützen-Tausch behoben
- Stabilisierung der Tablet-Schusszettel-Eingabe