### PR TITLE
Added functionality for Tables to handle links

### DIFF
--- a/bogenliga/src/app/modules/shared/components/tables/data-table/data-table.component.html
+++ b/bogenliga/src/app/modules/shared/components/tables/data-table/data-table.component.html
@@ -72,6 +72,15 @@
            {{getMappedText(row, column)}}
           </span>
 
+        <span *ngSwitchCase="TableColumnType.LINK">
+          <bla-actionbutton
+            [iconClass]="'th-list'"
+            (onClick)="linkClicked(row, column.linkTarget)"
+          >
+          {{ formatText(row, column) }}
+          </bla-actionbutton>
+        </span>
+
         <span *ngSwitchDefault>
             {{formatText(row, column)}}
           </span>

--- a/bogenliga/src/app/modules/shared/components/tables/data-table/data-table.component.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/data-table/data-table.component.ts
@@ -61,7 +61,6 @@ export class DataTableComponent extends CommonComponentDirective implements OnIn
   protected readonly ActionButtonColors = ActionButtonColors;
 
   public linkClicked(row: any, target: TableLinkTarget) {
-    console.log('Link clicked in data table component:', row, target);
     this.onLinkClicked.emit({row, target});
   }
 

--- a/bogenliga/src/app/modules/shared/components/tables/data-table/data-table.component.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/data-table/data-table.component.ts
@@ -17,8 +17,7 @@ import {CurrentUserService, UserPermission} from '@shared/services';
 import {ExpandComponent} from '@shared/components/expand';
 import {ActionButtonColors} from '@shared/components/buttons/button/actionbuttoncolors';
 import {IconProp} from '@fortawesome/fontawesome-svg-core';
-import {EnumValue} from "@angular/compiler-cli/src/ngtsc/partial_evaluator";
-import {TableLinkTarget} from "@shared/components/tables/types/table-column-link-target-type-enum";
+import {TableLinkTarget} from '@shared/components/tables/types/table-column-link-target-type-enum';
 
 
 @Component({
@@ -28,6 +27,12 @@ import {TableLinkTarget} from "@shared/components/tables/types/table-column-link
   providers:   [TranslatePipe, TruncationPipe]
 })
 export class DataTableComponent extends CommonComponentDirective implements OnInit, OnChanges {
+
+  constructor(private truncationPipe: TruncationPipe,
+              private translatePipe: TranslatePipe,
+              private currentUserService: CurrentUserService) {
+    super();
+  }
   @ViewChild(ExpandComponent) expandMenu: ExpandComponent;
   @Input() public config: TableConfig;
   @Input() public rows: TableRow[] = [];
@@ -53,11 +58,7 @@ export class DataTableComponent extends CommonComponentDirective implements OnIn
   initialized = false;
   private router: Router;
 
-  constructor(private truncationPipe: TruncationPipe,
-    private translatePipe: TranslatePipe,
-    private currentUserService: CurrentUserService) {
-    super();
-  }
+  protected readonly ActionButtonColors = ActionButtonColors;
 
   public linkClicked(row: any, target: TableLinkTarget) {
     console.log('Link clicked in data table component:', row, target);
@@ -66,7 +67,7 @@ export class DataTableComponent extends CommonComponentDirective implements OnIn
 
   // Returns true if actions in table should be displayed as colored buttons with text
   public hasColoredActionsWithText(): boolean {
-    if(this.config.hasOwnProperty('coloredActionsWithText') && this.config.coloredActionsWithText){
+    if (this.config.hasOwnProperty('coloredActionsWithText') && this.config.coloredActionsWithText) {
       return true;
     }
     return false;
@@ -74,8 +75,8 @@ export class DataTableComponent extends CommonComponentDirective implements OnIn
 
   // Gets icons for colored buttons
 
-  public getColoredActionsWithTextIcon(action: TableActionType): IconProp{
-    switch(action) {
+  public getColoredActionsWithTextIcon(action: TableActionType): IconProp {
+    switch (action) {
       case TableActionType.EDIT:
         return 'edit';
       case TableActionType.VIEW:
@@ -92,14 +93,14 @@ export class DataTableComponent extends CommonComponentDirective implements OnIn
   }
 
   // Gets translation key for colored buttons
-  public getColoredActionsWithTextTranslationKey(action: TableActionType): string{
-    let actionName = TableActionType[action];
+  public getColoredActionsWithTextTranslationKey(action: TableActionType): string {
+    const actionName = TableActionType[action];
     return 'TABLE.ACTION_TEXT.' + actionName;
   }
 
   // Gets color scheme for colored buttons
   public getColoredActionsWithTextColor(action: TableActionType): ActionButtonColors {
-    switch(action){
+    switch (action) {
       case TableActionType.DOWNLOAD:
       case TableActionType.DOWNLOADRUECKENNUMMER:
       case TableActionType.DOWNLOADLIZENZEN:
@@ -473,6 +474,4 @@ export class DataTableComponent extends CommonComponentDirective implements OnIn
     const sortingClasses = this.tableSorter.getSortingClasses(column);
     return sortingClasses.indexOf('sortable') > -1;
   }
-
-  protected readonly ActionButtonColors = ActionButtonColors;
 }

--- a/bogenliga/src/app/modules/shared/components/tables/data-table/data-table.component.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/data-table/data-table.component.ts
@@ -17,6 +17,8 @@ import {CurrentUserService, UserPermission} from '@shared/services';
 import {ExpandComponent} from '@shared/components/expand';
 import {ActionButtonColors} from '@shared/components/buttons/button/actionbuttoncolors';
 import {IconProp} from '@fortawesome/fontawesome-svg-core';
+import {EnumValue} from "@angular/compiler-cli/src/ngtsc/partial_evaluator";
+import {TableLinkTarget} from "@shared/components/tables/types/table-column-link-target-type-enum";
 
 
 @Component({
@@ -43,7 +45,7 @@ export class DataTableComponent extends CommonComponentDirective implements OnIn
   @Output() public onDownloadLizenzenEntry = new EventEmitter<VersionedDataObject>();
   @Output() public onColumnEntry = new EventEmitter<TableColumnConfig>();
   @Output() public onSelect: EventEmitter<any> = new EventEmitter<any>();
-  @Output() public onLinkClicked = new EventEmitter<{row: any; target: 'own' | 'opponent'}>();
+  @Output() public onLinkClicked = new EventEmitter<{row: any; target: TableLinkTarget}>();
 
   // do not remove, the view uses this enum
   public TableColumnType = TableColumnType;
@@ -57,7 +59,8 @@ export class DataTableComponent extends CommonComponentDirective implements OnIn
     super();
   }
 
-  public linkClicked(row: any, target: 'own' | 'opponent') {
+  public linkClicked(row: any, target: TableLinkTarget) {
+    console.log('Link clicked in data table component:', row, target);
     this.onLinkClicked.emit({row, target});
   }
 

--- a/bogenliga/src/app/modules/shared/components/tables/data-table/data-table.component.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/data-table/data-table.component.ts
@@ -43,6 +43,7 @@ export class DataTableComponent extends CommonComponentDirective implements OnIn
   @Output() public onDownloadLizenzenEntry = new EventEmitter<VersionedDataObject>();
   @Output() public onColumnEntry = new EventEmitter<TableColumnConfig>();
   @Output() public onSelect: EventEmitter<any> = new EventEmitter<any>();
+  @Output() public onLinkClicked = new EventEmitter<{row: any; target: 'own' | 'opponent'}>();
 
   // do not remove, the view uses this enum
   public TableColumnType = TableColumnType;
@@ -54,6 +55,10 @@ export class DataTableComponent extends CommonComponentDirective implements OnIn
     private translatePipe: TranslatePipe,
     private currentUserService: CurrentUserService) {
     super();
+  }
+
+  public linkClicked(row: any, target: 'own' | 'opponent') {
+    this.onLinkClicked.emit({row, target});
   }
 
   // Returns true if actions in table should be displayed as colored buttons with text

--- a/bogenliga/src/app/modules/shared/components/tables/types/table-column-config.interface.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/types/table-column-config.interface.ts
@@ -1,13 +1,14 @@
 import {TableColumnDateFormat} from './table-column-date-format.interface';
 import {TableColumnSortOrder} from './table-column-sort-order.enum';
 import {TableColumnType} from './table-column-type.enum';
+import {TableLinkTarget} from '@shared/components/tables/types/table-column-link-target-type-enum';
 
 export interface TableColumnConfig {
   /* tslint:disable */
   translationKey: string; // key of the column
   propertyName?: string; // to access the payload parameter field
   propertyMapper?: Function; // if defined maps extracted property
-  linkTarget?: string;
+  linkTarget?: TableLinkTarget;
   type?: TableColumnType; // optional: Use a specific data type pipe; default = TEXT
   localizationSet?: string; // optional: Used with TableColumnType.TRANSLATION_KEY
   width?: number; // optional: Set the column width in percent, e.g. '25'; default = width of content

--- a/bogenliga/src/app/modules/shared/components/tables/types/table-column-config.interface.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/types/table-column-config.interface.ts
@@ -7,7 +7,7 @@ export interface TableColumnConfig {
   translationKey: string; // key of the column
   propertyName?: string; // to access the payload parameter field
   propertyMapper?: Function; // if defined maps extracted property
-
+  linkTarget?: string;
   type?: TableColumnType; // optional: Use a specific data type pipe; default = TEXT
   localizationSet?: string; // optional: Used with TableColumnType.TRANSLATION_KEY
   width?: number; // optional: Set the column width in percent, e.g. '25'; default = width of content

--- a/bogenliga/src/app/modules/shared/components/tables/types/table-column-link-target-type-enum.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/types/table-column-link-target-type-enum.ts
@@ -1,4 +1,4 @@
 export enum TableLinkTarget {
     OWN = 'own',
-    OPPONENT = 'Opponent'
+    OPPONENT = 'opponent'
 }

--- a/bogenliga/src/app/modules/shared/components/tables/types/table-column-link-target-type-enum.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/types/table-column-link-target-type-enum.ts
@@ -1,0 +1,4 @@
+export enum TableLinkTarget {
+    OWN = 'own',
+    OPPONENT = 'Opponent'
+}

--- a/bogenliga/src/app/modules/shared/components/tables/types/table-column-type.enum.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/types/table-column-type.enum.ts
@@ -4,5 +4,6 @@ export enum TableColumnType {
   DATE,
   TRANSLATION_KEY, // i18n key
   CUSTOM_MAPPING, // use a function to manipulate the cell value
-  NULLORNUMBER= 5 // used in wkdurchfuehrung.config.ts to make sure null values are sorted before numbers
+  NULLORNUMBER= 5, // used in wkdurchfuehrung.config.ts to make sure null values are sorted before numbers
+  LINK
 }


### PR DESCRIPTION
Added functionality for Tables to handle links as actionbuttons and added two additional target parameters to support up to two differnt links in a single row with linkTarget: 'own' | 'opponent'