### PR TITLE
Layout-Verbesserung – Statusleiste in der Tablet-Schusszettel-Eingabe

### DIFF
--- a/bogenliga/src/app/modules/schusszettel/components/shared/tablet-statusleiste/tablet-statusleiste.component.html
+++ b/bogenliga/src/app/modules/schusszettel/components/shared/tablet-statusleiste/tablet-statusleiste.component.html
@@ -1,0 +1,28 @@
+<div class="timeline" *ngIf="!hideBar">
+
+  <div class="timeline__track">
+
+    <ng-container *ngFor="let step of steps; let i = index">
+
+      <!-- Schritt -->
+      <div
+        class="timeline__step"
+        [class.active]="isActive(i)"
+        [class.done]="isDone(i)"
+      >
+        <div class="dot"></div>
+        <div class="label">{{ step.label }}</div>
+      </div>
+
+      <!-- Verbindungslinie -->
+      <div
+        class="line"
+        *ngIf="i < steps.length - 1"
+        [class.done]="isDone(i)"
+      ></div>
+
+    </ng-container>
+
+  </div>
+
+</div>

--- a/bogenliga/src/app/modules/schusszettel/components/shared/tablet-statusleiste/tablet-statusleiste.component.scss
+++ b/bogenliga/src/app/modules/schusszettel/components/shared/tablet-statusleiste/tablet-statusleiste.component.scss
@@ -1,0 +1,67 @@
+.timeline {
+  margin: 20px 0;
+}
+
+.timeline__track {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+/* einzelner Schritt */
+.timeline__step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 120px;
+}
+
+.timeline__step .dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #cbd5e1;
+  margin-bottom: 6px;
+}
+
+.timeline__step .label {
+  font-size: 14px;
+  color: #475569;
+  text-align: center;
+  white-space: nowrap;
+}
+
+/* Linie zwischen Schritten */
+.line {
+  flex: 1;
+  height: 2px;
+  background: #cbd5e1;
+  margin: 0 10px;
+}
+
+/* aktiver Schritt */
+.timeline__step.active .dot {
+  background: #2563eb;
+}
+
+.timeline__step.active .label {
+  font-weight: 600;
+  color: #1e3a8a;
+}
+
+/* erledigte Schritte */
+.timeline__step.done .dot {
+  background: #64748b;
+}
+
+.line.done {
+  background: #64748b;
+}
+
+/* Text unten */
+.timeline__info {
+  margin-top: 10px;
+  text-align: center;
+  font-size: 13px;
+  color: #475569;
+}

--- a/bogenliga/src/app/modules/schusszettel/components/shared/tablet-statusleiste/tablet-statusleiste.component.ts
+++ b/bogenliga/src/app/modules/schusszettel/components/shared/tablet-statusleiste/tablet-statusleiste.component.ts
@@ -1,0 +1,100 @@
+import { Component, Input } from '@angular/core';
+
+export type TabletStatus =
+  | 'NOT_ALLOWED'
+  | 'WARTE'
+  | 'SCHUETZENMELDUNG'
+  | 'SATZEINGABE'
+  | 'MATCH_ENDE'
+  | 'WETTKAMPF_BEENDET'
+  | string;
+
+type StepKey =
+  | 'UEBERSICHT'
+  | 'SCHUETZENMELDUNG'
+  | 'SATZEINGABE'
+  | 'WARTE';
+
+@Component({
+  selector: 'bla-tablet-statusleiste',
+  templateUrl: './tablet-statusleiste.component.html',
+  styleUrls: ['./tablet-statusleiste.component.scss'],
+})
+export class TabletStatusleisteComponent {
+  @Input() status!: TabletStatus;
+  @Input() showZustandFirst = true;
+
+  /** Status, bei dem wir die Leiste gar nicht anzeigen wollen */
+  get hideBar(): boolean {
+    return this.status === 'NOT_ALLOWED';
+  }
+
+  /** Schritte dynamisch nach aktuellem Status */
+  get steps(): Array<{ key: StepKey; label: string }> {
+    const base: Array<{ key: StepKey; label: string }> = [
+      { key: 'UEBERSICHT', label: 'Übersicht' },
+    ];
+
+    if (this.status === 'SCHUETZENMELDUNG') {
+      return [
+        ...base,
+        { key: 'SCHUETZENMELDUNG', label: 'Schützenmeldung' },
+        { key: 'SATZEINGABE', label: 'Passe' },
+        { key: 'WARTE', label: 'Warten' },
+      ];
+    }
+
+    if (this.status === 'SATZEINGABE') {
+      return [
+        ...base,
+        { key: 'SATZEINGABE', label: 'Pässe' },
+        { key: 'WARTE', label: 'Warten' },
+      ];
+    }
+
+    if (this.status === 'WARTE') {
+      return [
+        ...base,
+        { key: 'WARTE', label: 'Warten' },
+      ];
+    }
+
+    // Für andere Stati (MATCH_ENDE, WETTKAMPF_BEENDET, unknown)
+    return base;
+  }
+
+
+  private get currentStepKey(): StepKey | null {
+    if (this.status === 'SCHUETZENMELDUNG') return 'SCHUETZENMELDUNG';
+    if (this.status === 'SATZEINGABE') return 'SATZEINGABE';
+    if (this.status === 'WARTE') return 'WARTE';
+    return null;
+  }
+
+
+  private get activeStepKey(): StepKey | null {
+    if (
+      this.showZustandFirst &&
+      (this.status === 'SCHUETZENMELDUNG' || this.status === 'SATZEINGABE')
+    ) {
+      return 'UEBERSICHT';
+    }
+    return this.currentStepKey;
+  }
+
+
+  get activeIndex(): number {
+    const key = this.activeStepKey;
+    if (!key) return -1;
+    return this.steps.findIndex((s) => s.key === key);
+  }
+
+  isActive(i: number): boolean {
+    return i === this.activeIndex;
+  }
+
+  isDone(i: number): boolean {
+    return this.activeIndex >= 0 && i < this.activeIndex;
+  }
+
+}

--- a/bogenliga/src/app/modules/schusszettel/components/tablet/tablet.component.html
+++ b/bogenliga/src/app/modules/schusszettel/components/tablet/tablet.component.html
@@ -12,6 +12,12 @@
 
   <!-- 3) Main content only when loaded and no error -->
   <ng-container *ngIf="!loading && data">
+
+    <bla-tablet-statusleiste
+      [status]="data.status"
+      [showZustandFirst]="showZustandFirst">
+    </bla-tablet-statusleiste>
+
     <ng-container [ngSwitch]="data.status">
 
       <!-- Not allowed -->
@@ -34,6 +40,7 @@
           [infos]="data"
           (weiter)="onZustandWeiter()">
         </bla-maske4zustand>
+
         <bla-maske1registrierung
           *ngIf="!showZustandFirst"
           [infos]="data"
@@ -48,11 +55,11 @@
           [infos]="data"
           (weiter)="onZustandWeiter()">
         </bla-maske4zustand>
+
         <bla-maske2eingabe
           *ngIf="!showZustandFirst"
           [infos]="data"
-          (satzSubmit)="onSatz($event)"
-          (abort)="onPasseAbort()">
+          (satzSubmit)="onSatz($event)">
         </bla-maske2eingabe>
       </ng-container>
 
@@ -70,6 +77,7 @@
           [infos]="data"
           (weiter)="onZustandWeiter()">
         </bla-maske4zustand>
+
         <bla-maske4wettkampbeendet
           *ngIf="!showZustandFirst"
           [infos]="data"
@@ -79,7 +87,8 @@
 
       <!-- Unexpected status -->
       <div *ngSwitchDefault class="error-box">
-        Unbekannter Status "{{ data.status }}". Bitte wenden Sie sich an den Support.
+        Unbekannter Status "{{ data.status }}".
+        Bitte wenden Sie sich an den Support.
       </div>
 
     </ng-container>

--- a/bogenliga/src/app/modules/schusszettel/components/tablet/tablet.component.ts
+++ b/bogenliga/src/app/modules/schusszettel/components/tablet/tablet.component.ts
@@ -1,15 +1,15 @@
-import {Component, OnDestroy, OnInit} from '@angular/core';
-import {ActivatedRoute} from '@angular/router';
-import {SchusszettelService} from '../../services/schusszettel.service';
-import {TabletSchusszettel} from '../../models/tablet-schusszettel.model';
-import {SchuetzenSatzDTO} from '../../types/datatransfer/satz-eingabe-dto';
-import {Subject} from 'rxjs';
-import {takeUntil} from 'rxjs/operators';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { SchusszettelService } from '../../services/schusszettel.service';
+import { TabletSchusszettel } from '../../models/tablet-schusszettel.model';
+import { SchuetzenSatzDTO } from '../../types/datatransfer/satz-eingabe-dto';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'bla-tablet',
   templateUrl: './tablet.component.html',
-  styleUrls: ['./tablet.component.scss']
+  styleUrls: ['./tablet.component.scss'],
 })
 export class TabletComponent implements OnInit, OnDestroy {
   token!: string;
@@ -30,13 +30,13 @@ export class TabletComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.route.queryParamMap
-        .pipe(takeUntil(this.destroy$))
-        .subscribe((params) => {
-          this.token       = params.get('token')!;
-          this.teamId      = Number(params.get('teamid'));
-          this.wettkampfId = Number(params.get('wettkampfid'));
-          this.load();
-        });
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((params) => {
+        this.token = params.get('token')!;
+        this.teamId = Number(params.get('teamid'));
+        this.wettkampfId = Number(params.get('wettkampfid'));
+        this.load();
+      });
   }
 
   load(): void {
@@ -46,44 +46,56 @@ export class TabletComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.loading  = true;
+    this.loading = true;
     this.errorMsg = null;
 
     this.schussService
-        .getSchusszettel(this.token, this.wettkampfId, this.teamId)
-        .pipe(takeUntil(this.destroy$))
-        .subscribe({
-          next: (resp) => {
-            this.data    = resp;
-            this.loading = false;
-            this.showZustandFirst = true;
-          },
-          error: (err) => {
-            console.error('Fehler beim Laden:', err);
-            this.errorMsg = 'Daten konnten nicht geladen werden. Bitte später erneut versuchen.';
-            this.loading  = false;
-          }
-        });
+      .getSchusszettel(this.token, this.wettkampfId, this.teamId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (resp) => {
+          this.data = resp;
+          console.log('TABLET DATA:', resp);
+          this.loading = false;
+          this.showZustandFirst = true;
+        },
+        error: (err) => {
+          console.error('Fehler beim Laden:', err);
+          this.errorMsg =
+            'Daten konnten nicht geladen werden. Bitte später erneut versuchen.';
+          this.loading = false;
+        },
+      });
   }
 
   onRegister(meldungen: number[]): void {
     this.schussService
-        .postSchuetzenMeldung(this.token, this.wettkampfId, this.teamId, meldungen)
-        .pipe(takeUntil(this.destroy$))
-        .subscribe({
-          next: ()  => this.load(),
-          error: (err) => console.error('Registrierungsfehler:', err)
-        });
+      .postSchuetzenMeldung(
+        this.token,
+        this.wettkampfId,
+        this.teamId,
+        meldungen
+      )
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => this.load(),
+        error: (err) => console.error('Registrierungsfehler:', err),
+      });
   }
 
   onSatz(satzeingabe: SchuetzenSatzDTO[]): void {
     this.schussService
-        .postSatzEingabe(this.token, this.wettkampfId, this.teamId, satzeingabe)
-        .pipe(takeUntil(this.destroy$))
-        .subscribe({
-          next: ()  => this.load(),
-          error: (err) => console.error('Eingabefehler:', err)
-        });
+      .postSatzEingabe(
+        this.token,
+        this.wettkampfId,
+        this.teamId,
+        satzeingabe
+      )
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => this.load(),
+        error: (err) => console.error('Eingabefehler:', err),
+      });
   }
 
   onZustandWeiter(): void {
@@ -101,14 +113,5 @@ export class TabletComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
-  }
-
-  /**
-   * Aborts the current passe input and returns to the initial state view.
-   * This is used when the passe input cannot be performed safely,
-   * for example if the shooter data is inconsistent.
-   */
-  onPasseAbort(): void {
-    this.showZustandFirst = true;
   }
 }

--- a/bogenliga/src/app/modules/schusszettel/schusszettel.module.ts
+++ b/bogenliga/src/app/modules/schusszettel/schusszettel.module.ts
@@ -24,6 +24,7 @@ import {MatchKontextComponent} from './components/shared/match-kontext/match-kon
 import {SchusszettelRoutingModule} from '@schusszettel/schusszettel.routing.module';
 import {MatTooltipModule} from '@angular/material/tooltip';
 import {WkdurchfuehrungModule} from '../wkdurchfuehrung/wkdurchfuehrung.module';
+import {TabletStatusleisteComponent} from './components/shared/tablet-statusleiste/tablet-statusleiste.component';
 
 @NgModule({
   declarations: [
@@ -32,6 +33,7 @@ import {WkdurchfuehrungModule} from '../wkdurchfuehrung/wkdurchfuehrung.module';
     WarteBestaetigungComponent,
     SchusszettelTabletAdminComponent,
     TabletComponent,
+    TabletStatusleisteComponent,
     NotAllowedComponent,
     WettkampfbeendetComponent,
     Maske4ZustandComponent,


### PR DESCRIPTION
In der Tableteingabe ist nun eine Statusleiste vorhanden, die je nach Zustand (Schützenmeldung, Satzeingabe, Warte) eine Statusleiste anzeigt und anpasst, sodass die Nutzenden einen Überblick haben, in welchem Zustand sie sich befinden und welcher noch bevorsteht.