### PR TITLE
2039: Add link to league table on league detail page

### DIFF
--- a/bogenliga/src/app/modules/home/components/home/home.component.html
+++ b/bogenliga/src/app/modules/home/components/home/home.component.html
@@ -135,6 +135,15 @@
             (onClick)="deselect()">
             {{ 'HOME.LIGADETAILES.BACK_TO_HOME' | translate }}
           </bla-actionbutton>
+
+          <bla-actionbutton
+            [id]="'ligaHomeTabelleButton'"
+            [color]="ActionButtonColors.PRIMARY"
+            [iconClass]="'list-ol'"
+            (onClick)="ligaHomeTabelleLinking()">
+            Zur Tabelle
+          </bla-actionbutton>
+
         </div>
       </div>
 

--- a/bogenliga/src/app/modules/home/components/home/home.component.ts
+++ b/bogenliga/src/app/modules/home/components/home/home.component.ts
@@ -30,6 +30,7 @@ import {faHome} from '@fortawesome/free-solid-svg-icons';
 import {IconProp} from '@fortawesome/fontawesome-svg-core';
 import { RecentLigaService, RecentLigaEntry } from '@shared/services';
 import { slugifyLigaName } from '@shared/functions/slug-utils';
+import { buildLigaTabelleLink } from '@shared/functions/liga-route-utils';
 
 //for notification
 import {
@@ -694,6 +695,24 @@ export class HomeComponent extends CommonComponentDirective implements OnInit, O
       { queryParamsHandling: 'merge' }
     );
   }
+
+  public ligaHomeTabelleLinking() {
+    if (!this.selectedLigaID || !this.selectedLigaName) {
+      return;
+    }
+
+    const ligaParam = slugifyLigaName(this.selectedLigaName);
+
+    this.router.navigate(
+      ['/ligatabelle'],
+      {
+        queryParams: { liga: ligaParam },
+        queryParamsHandling: 'merge'
+      }
+    );
+  }
+
+
 
   public wettkampfButtonToLigatabelleLinking(
     ligaId: number,


### PR DESCRIPTION
Umsetzung von Ticket #2039.

- Link/Button zur Ligatabelle auf der ligaspezifischen Seite ergänzt
- Navigation zur Ligatabelle über bestehendes Routing umgesetzt
- Styling gemäß bestehender Buttons beibehalten

Geänderte Dateien:
- home.component.html
- home.component.ts