### PR TITLE
Ticket 2040: Hintergrundfarbe der Menüpunkte auf leichtes Grau gesetzt

### DIFF
--- a/bogenliga/src/app/components/sidebar/sidebar.component.scss
+++ b/bogenliga/src/app/components/sidebar/sidebar.component.scss
@@ -256,8 +256,8 @@ div.sidebar-text-toggle.flexBox{
 }
 
 // Highlight "Wettkämpfe" and "Ligatabelle" menu items with a light gray background
-a[data-cy="sidebar-wettkampf-button"],
-a[data-cy="sidebar-ligatabelle-button"] {
+.sidebar-text-toggle:has(a[data-cy="sidebar-wettkampf-button"]),
+.sidebar-text-toggle:has(a[data-cy="sidebar-ligatabelle-button"]) {
   background-color: #F2F2F5;
 }
 // for small devices

--- a/bogenliga/src/app/components/sidebar/sidebar.component.scss
+++ b/bogenliga/src/app/components/sidebar/sidebar.component.scss
@@ -255,7 +255,11 @@ div.sidebar-text-toggle.flexBox{
   color:$hero-blue;
 }
 
-
+// Highlight "Wettkämpfe" and "Ligatabelle" menu items with a light gray background
+a[data-cy="sidebar-wettkampf-button"],
+a[data-cy="sidebar-ligatabelle-button"] {
+  background-color: #F2F2F5;
+}
 // for small devices
 @media (max-width: 768px) {
   #sidebar {

--- a/bogenliga/src/app/components/sidebar/sidebar.component.scss
+++ b/bogenliga/src/app/components/sidebar/sidebar.component.scss
@@ -258,7 +258,7 @@ div.sidebar-text-toggle.flexBox{
 // Highlight "Wettkämpfe" and "Ligatabelle" menu items with a light gray background
 .sidebar-text-toggle:has(a[data-cy="sidebar-wettkampf-button"]),
 .sidebar-text-toggle:has(a[data-cy="sidebar-ligatabelle-button"]) {
-  background-color: #F2F2F5;
+  background-color: $light-gray;
 }
 // for small devices
 @media (max-width: 768px) {


### PR DESCRIPTION
Ticket #2040 gelöst. Die Menüpunkte für Wettkämpfe und Ligatabelle haben jetzt wie gefordert den grauen Hintergrund."