### PR TITLE
[epic-6] BSAPP-1926 frontend duplicate conflict handling

### DIFF
--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/mannschaft-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/mannschaft-detail.component.ts
@@ -86,6 +86,7 @@ export class MannschaftDetailComponent extends CommonComponentDirective implemen
   // maps the MannschaftsMitgliedDO with the DSBMitgliedId
   private currentMannschaftsMitglied: MannschaftsMitgliedDO = new MannschaftsMitgliedDO();
   private members: Map<number, MannschaftsMitgliedDO> = new Map<number, MannschaftsMitgliedDO>();
+  private duplicateNotificationSubscription;
   private deleteNotification: Notification;
   private deleteSubscription;
   private dsbmitglied: DsbMitgliedDO = new DsbMitgliedDO();
@@ -137,6 +138,14 @@ export class MannschaftDetailComponent extends CommonComponentDirective implemen
         }
       }
     });
+
+    this.duplicateNotificationSubscription = this.notificationService.observeNotification(NOTIFICATION_DUPLICATE_MANNSCHAFT)
+      .subscribe((notification) => {
+        if (notification.userAction === NotificationUserAction.ACCEPTED
+          || notification.userAction === NotificationUserAction.DECLINED) {
+          this.saveLoading = false;
+        }
+      });
   }
 
   /** When a MouseOver-Event is triggered, it will call this inMouseOver-function.
@@ -153,6 +162,9 @@ export class MannschaftDetailComponent extends CommonComponentDirective implemen
 
 
   ngOnDestroy() {
+    if (this.duplicateNotificationSubscription != null) {
+      this.duplicateNotificationSubscription.unsubscribe();
+    }
     if (this.deleteSubscription != null) {
       this.deleteSubscription.unsubscribe();
     }
@@ -160,6 +172,7 @@ export class MannschaftDetailComponent extends CommonComponentDirective implemen
 
 
   public onSave(ignore: any) {
+    this.notificationService.discardNotification();
     this.saveLoading = true;
     // persist
     this.currentMannschaft.vereinId = this.currentVerein.id; // Set selected verein id// set selected veranstaltung id
@@ -171,6 +184,7 @@ export class MannschaftDetailComponent extends CommonComponentDirective implemen
     }
 
   public onUpdate(ignore: any): void {
+    this.notificationService.discardNotification();
     this.saveLoading = true;
 
     // persist
@@ -711,6 +725,8 @@ export class MannschaftDetailComponent extends CommonComponentDirective implemen
   }
 
   private showDuplicateMannschaftNotification(): void {
+    this.notificationService.discardNotification();
+
     const notification: Notification = {
       id:          NOTIFICATION_DUPLICATE_MANNSCHAFT,
       title:       'MANAGEMENT.VEREIN_DETAIL.NOTIFICATION.DUPLICATE.TITLE',

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, OnInit, ViewChild} from '@angular/core';
+import {Component, ElementRef, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
 import {isNullOrUndefined, isUndefined} from '@shared/functions';
 import {
@@ -56,6 +56,8 @@ const NOTIFICATION_COPY_MANNSCHAFT = 'mannschaft_detail_copy';
 const NOTIFICATION_DELETE_MANNSCHAFT_SUCCESS = 'mannschaft_detail_delete_success';
 const NOTIFICATION_DELETE_MANNSCHAFT_FAILURE = 'mannschaft_detail_delete_failure';
 const NOTIFICATION_NO_LICENSE = 'no_license_found';
+const NOTIFICATION_ENTITY_CONFLICT_ERROR = 'ENTITY_CONFLICT_ERROR';
+const NOTIFICATION_DATABASE_ERROR = 'DATABASE_ERROR';
 const PLATZHALTER_ID = 99;
 
 @Component({
@@ -63,7 +65,7 @@ const PLATZHALTER_ID = 99;
   templateUrl: './verein-detail.component.html',
   styleUrls:   ['./verein-detail.component.scss']
 })
-export class VereinDetailComponent extends CommonComponentDirective implements OnInit {
+export class VereinDetailComponent extends CommonComponentDirective implements OnInit, OnDestroy {
   public regionType = 'KREIS';
   public config = VEREIN_DETAIL_CONFIG;
   public config_table = VEREIN_DETAIL_TABLE_CONFIG;
@@ -80,6 +82,7 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
 
 
   private sessionHandling: SessionHandling;
+  private saveErrorNotificationSubscriptions = [];
 
   @ViewChild('downloadLink')
   private aElementRef: ElementRef;
@@ -103,7 +106,13 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
   ngOnInit() {
     this.loading = true;
     this.notificationService.discardNotification();
+    this.registerSaveErrorReset(NOTIFICATION_ENTITY_CONFLICT_ERROR);
+    this.registerSaveErrorReset(NOTIFICATION_DATABASE_ERROR);
     this.loadRegions(this.regionType); // Request all regions from the backend
+  }
+
+  ngOnDestroy() {
+    this.saveErrorNotificationSubscriptions.forEach((subscription) => subscription.unsubscribe());
   }
 
   /** When a MouseOver-Event is triggered, it will call this inMouseOver-function.
@@ -136,6 +145,7 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
   }
 
   public onSave(ignore: any): void {
+    this.notificationService.discardNotification();
     this.saveLoading = true;
 
     // persist
@@ -186,6 +196,7 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
   }
 
   public onUpdate(ignore: any): void {
+    this.notificationService.discardNotification();
     this.saveLoading = true;
 
     // persist
@@ -616,6 +627,18 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
     this.currentRegion = this.regionen[0]; // Set first element of object as selected.
 
     this.loading = false;
+  }
+
+  private registerSaveErrorReset(notificationId: string): void {
+    const subscription = this.notificationService.observeNotification(notificationId)
+      .subscribe((notification) => {
+        if (notification.userAction === NotificationUserAction.ACCEPTED
+          || notification.userAction === NotificationUserAction.DECLINED) {
+          this.saveLoading = false;
+        }
+      });
+
+    this.saveErrorNotificationSubscriptions.push(subscription);
   }
 
   private loadMannschaften() {

--- a/bogenliga/src/assets/i18n/de.json
+++ b/bogenliga/src/assets/i18n/de.json
@@ -1048,8 +1048,8 @@
           "DESCRIPTION": "Verein wurde erfolgreich gespeichert."
         },
         "DUPLICATE": {
-          "TITLE": "Mannschaftsnummer in dem Verein bereits vergeben!",
-          "DESCRIPTION": "Möchten sie die Mannschaft trotzdem hinzufügen?"
+          "TITLE": "Doppelte Mannschaft",
+          "DESCRIPTION": "Die Mannschaftsnummer ist in diesem Verein bereits vergeben. Bitte wählen Sie eine andere Nummer."
         },
         "SAVE_FAILURE": {
           "TITLE": "Fehler beim Aktualisieren",
@@ -1901,6 +1901,10 @@
       "DATABASE_ERROR": {
         "TITLE": "Datenbankfehler",
         "DESCRIPTION": "Ihre Anfrage wurde von der Datenbank abgewiesen."
+      },
+      "ENTITY_CONFLICT_ERROR": {
+        "TITLE": "Doppelte Eingabe",
+        "DESCRIPTION": "Ein Eintrag mit diesen Werten existiert bereits. Bitte prüfen Sie Ihre Eingaben."
       },
       "ENTITY_NOT_FOUND_ERROR": {
         "TITLE": "Nicht gefunden",


### PR DESCRIPTION
## Summary
- implement the frontend part of BSAPP-1926 in the verein administration dialogs
- show a clearer duplicate/conflict flow instead of leaving the user with a stuck save state
- reset `saveLoading` after duplicate and database-related notifications are acknowledged

## What Changed
- added duplicate-notification reset handling in the mannschaft detail dialog
- added save-error reset handling in the verein detail dialog for `ENTITY_CONFLICT_ERROR` and `DATABASE_ERROR`
- kept the duplicate Mannschaft translation aligned with the team dialog wording
- added a clearer global translation for `ENTITY_CONFLICT_ERROR`

## Why
The original duplicate handling around ticket 1926 was only partially covered in the UI flow. In practice, users could still hit a generic database error in the verein dialog and the green save button could remain in a loading state after clicking `OK`.

## Impact
- duplicate/conflict feedback is clearer in the UI
- users can retry saving without refreshing the page after acknowledging the error dialog
- the change is minimal and scoped to the affected verein/mannschaft flows

## Validation
- no dedicated frontend test was run locally for this patch
- backend-side conflict handling for the related flow was covered separately in the paired backend PR
