### PR TITLE
#2081 zugriff auf vergangene sportjahre

### DIFF
--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.html
@@ -229,12 +229,16 @@
       <!-- Dropdown for Sports Year -->
       <div class="form-group row">
         <label class="col-sm-3 col-form-label" for="sportsYearDropdown">
-          <span>{{ 'Sportjahr'  }}</span>
+          <span>{{ 'MANAGEMENT.VEREIN_DETAIL.TABLE.DROPDOWN.SPORTJAHR.LABEL' | translate }}</span>
         </label>
         <div class="col-sm-9">
           <select id="sportsYearDropdown"
-                  class="form-control">
-            <option *ngFor="let year of [2026, 2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016]" [value]="year">
+                  class="form-control"
+                  name="sportsYearDropdown"
+                  [ngModel]="selectedSportjahr"
+                  (ngModelChange)="onSportjahrChange($event)">
+            <option [ngValue]="null">{{ 'MANAGEMENT.VEREIN_DETAIL.TABLE.DROPDOWN.SPORTJAHR.ALL' | translate }}</option>
+            <option *ngFor="let year of availableSportjahre" [ngValue]="year">
               {{ year }}
             </option>
           </select>

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.html
@@ -224,6 +224,23 @@
           <span> Neu</span>
         </bla-actionbutton>
       </div>
+
+
+      <!-- Dropdown for Sports Year -->
+      <div class="form-group row">
+        <label class="col-sm-3 col-form-label" for="sportsYearDropdown">
+          <span>{{ 'Sportjahr'  }}</span>
+        </label>
+        <div class="col-sm-9">
+          <select id="sportsYearDropdown"
+                  class="form-control">
+            <option *ngFor="let year of [2026, 2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016]" [value]="year">
+              {{ year }}
+            </option>
+          </select>
+        </div>
+      </div>
+
       <bla-data-table (onDeleteEntry)="onDeleteMannschaft($event)"
                       (onDownloadLizenzenEntry)="onDownloadLizenzen($event)"
                       (onDownloadRueckennummerEntry)="onDownloadRueckennummer($event)"

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.ts
@@ -631,8 +631,17 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
   private loadMannschaftenByVereinsIdAndSportjahr() {
     this.loading = true;
     if (this.selectedSportjahr === null) {
-      this.mannschaftsDataProvider.findAllByVereinsId(this.currentVerein.id)
-        .then((response: BogenligaResponse<DsbMannschaftDTO[]>) => this.handleLoadMannschaftenSuccess(response))
+      const jahreRequests = this.availableSportjahre.map(jahr =>
+        this.mannschaftsDataProvider.findAllByVereinsIdAndSportjahr(this.currentVerein.id, jahr)
+      );
+      const warteschlangeRequest = this.mannschaftsDataProvider.findAllByWarteschlangeId();
+      Promise.all([...jahreRequests, warteschlangeRequest])
+        .then(responses => {
+          const warteschlangeResponse = responses[responses.length - 1];
+          const ohneJahr = (warteschlangeResponse.payload as any[]).filter(m => m.vereinId === this.currentVerein.id);
+          const mitJahr = responses.slice(0, -1).reduce((acc: DsbMannschaftDTO[], r) => acc.concat(r.payload as any), []);
+          this.handleLoadMannschaftenSuccess({result: RequestResult.SUCCESS, payload: [...mitJahr, ...ohneJahr]});
+        })
         .catch((response: BogenligaResponse<DsbMannschaftDTO[]>) => this.handleLoadMannschaftenFailure(response));
     } else {
       this.mannschaftsDataProvider.findAllByVereinsIdAndSportjahr(this.currentVerein.id, this.selectedSportjahr)
@@ -641,22 +650,27 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
     }
   }
 
-  private loadSportjahre (): void{
-    this.mannschaftsDataProvider.findAllByVereinsId(this.currentVerein.id)
+  private loadSportjahre(): void {
+    this.mannschaftsDataProvider.findAllSportjahre()
       .then(response => {
-        const jahre = response.payload
-          .map(m => m.sportjahr)          // alle sportjahr-Felder extrahieren
-          .filter(j => j != null)          // null-Werte raus
-          .filter((j, i, arr) => arr.indexOf(j) === i)  // Duplikate raus
-          .sort((a, b) => b - a);          // absteigend: neuestes Jahr zuerst
-
-        this.availableSportjahre = jahre;
-        this.selectedSportjahr = null;
-        this.loadMannschaftenByVereinsIdAndSportjahr();        // Tabelle laden
+        const alleJahre = response.payload;
+        return Promise.all(
+          alleJahre.map(jahr =>
+            this.mannschaftsDataProvider.findAllByVereinsIdAndSportjahr(this.currentVerein.id, jahr)
+              .then(r => ({jahr, hatMannschaften: r.payload.length > 0}))
+              .catch(() => ({jahr, hatMannschaften: false}))
+          )
+        );
       })
-
+      .then(ergebnisse => {
+        this.availableSportjahre = ergebnisse
+          .filter(e => e.hatMannschaften)
+          .map(e => e.jahr);
+        this.selectedSportjahr = null;
+        this.loadMannschaftenByVereinsIdAndSportjahr();
+      })
       .catch(() => {
-        this.loadMannschaften(); // Fallback: Alle Mannschaften laden, wenn Sportjahre nicht ermittelt werden können
+        this.loadMannschaften();
       });
   }
 

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.ts
@@ -74,6 +74,9 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
   public regionen: Array<RegionDO> = [new RegionDO()];
   public mannschaften: Array<DsbMannschaftDO> = [new DsbMannschaftDO()];
 
+  public selectedSportjahr : number = null; //Auswahl im Dropdown
+  public availableSportjahre: number [] = []; //Liste im Dropdown
+
   public deleteLoading = false;
   public saveLoading = false;
   public ActionButtonColors = ActionButtonColors;
@@ -342,7 +345,7 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
 
                                     if (myNotification.userAction === NotificationUserAction.ACCEPTED) {
                                       this.mannschaftsDataProvider.deleteById(id)
-                                          .then((response) => this.loadMannschaften())
+                                          .then((response) => this.loadMannschaftenByVereinsIdAndSportjahr())
                                           .catch((response) => this.rows = hideLoadingIndicator(this.rows, id));
                                     } else if (myNotification.userAction === NotificationUserAction.DECLINED) {
                                       this.rows = hideLoadingIndicator(this.rows, id);
@@ -377,7 +380,7 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
 
         if (myNotification.userAction === NotificationUserAction.ACCEPTED) {
           this.mannschaftsDataProvider.copyMannschaft(id)
-            .then((response) => this.loadMannschaften())
+            .then((response) => this.loadMannschaftenByVereinsIdAndSportjahr())
             .catch((response) => this.rows = hideLoadingIndicator(this.rows, id));
         } else if (myNotification.userAction === NotificationUserAction.DECLINED) {
           this.rows = hideLoadingIndicator(this.rows, id);
@@ -527,7 +530,7 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
 
   private handleSuccess(response: BogenligaResponse<VereinDO>) {
     this.currentVerein = response.payload;
-    this.loadMannschaften();
+    this.loadSportjahre();
     this.loading = false;
 
     this.currentRegion = this.regionen.filter((region) => region.id === this.currentVerein.regionId)[0];
@@ -623,6 +626,43 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
     this.mannschaftsDataProvider.findAllByVereinsId(this.currentVerein.id)
         .then((response: BogenligaResponse<DsbMannschaftDTO[]>) => this.handleLoadMannschaftenSuccess(response))
         .catch((response: BogenligaResponse<DsbMannschaftDTO[]>) => this.handleLoadMannschaftenFailure(response));
+  }
+
+  private loadMannschaftenByVereinsIdAndSportjahr() {
+    this.loading = true;
+    if (this.selectedSportjahr === null) {
+      this.mannschaftsDataProvider.findAllByVereinsId(this.currentVerein.id)
+        .then((response: BogenligaResponse<DsbMannschaftDTO[]>) => this.handleLoadMannschaftenSuccess(response))
+        .catch((response: BogenligaResponse<DsbMannschaftDTO[]>) => this.handleLoadMannschaftenFailure(response));
+    } else {
+      this.mannschaftsDataProvider.findAllByVereinsIdAndSportjahr(this.currentVerein.id, this.selectedSportjahr)
+        .then((response: BogenligaResponse<DsbMannschaftDTO[]>) => this.handleLoadMannschaftenSuccess(response))
+        .catch((response: BogenligaResponse<DsbMannschaftDTO[]>) => this.handleLoadMannschaftenFailure(response));
+    }
+  }
+
+  private loadSportjahre (): void{
+    this.mannschaftsDataProvider.findAllByVereinsId(this.currentVerein.id)
+      .then(response => {
+        const jahre = response.payload
+          .map(m => m.sportjahr)          // alle sportjahr-Felder extrahieren
+          .filter(j => j != null)          // null-Werte raus
+          .filter((j, i, arr) => arr.indexOf(j) === i)  // Duplikate raus
+          .sort((a, b) => b - a);          // absteigend: neuestes Jahr zuerst
+
+        this.availableSportjahre = jahre;
+        this.selectedSportjahr = null;
+        this.loadMannschaftenByVereinsIdAndSportjahr();        // Tabelle laden
+      })
+
+      .catch(() => {
+        this.loadMannschaften(); // Fallback: Alle Mannschaften laden, wenn Sportjahre nicht ermittelt werden können
+      });
+  }
+
+  public onSportjahrChange(year : number) : void{
+    this.selectedSportjahr = year;
+    this.loadMannschaftenByVereinsIdAndSportjahr();
   }
 
   private handleLoadMannschaftenSuccess(response: BogenligaResponse<DsbMannschaftDTO[]>): void {

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-overview/verein-overview.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-overview/verein-overview.component.html
@@ -13,17 +13,3 @@
                      (onSearchClicked)="findBySearch($event)">
   <div (mouseover)="onMouseOver($event)"></div>
 </bla-overview-dialog>
-
-<div class="form-group row">
-  <label class="col-sm-3 col-form-label" for="sportsYearDropdown">
-    <span>{{ 'Sportjahr'  }}</span>
-  </label>
-  <div class="col-sm-9">
-    <select id="sportsYearDropdown"
-            class="form-control">
-      <option *ngFor="let year of [2026, 2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016]" [value]="year">
-        {{ year }}
-      </option>
-    </select>
-  </div>
-</div>

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-overview/verein-overview.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-overview/verein-overview.component.html
@@ -1,5 +1,7 @@
 <bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:vereine-uebersicht"
                   target="_blank"></bla-hilfe-button>
+
+
 <bla-overview-dialog [hidden]=false
                      [config]="config"
                      [rows]="rows"
@@ -11,3 +13,17 @@
                      (onSearchClicked)="findBySearch($event)">
   <div (mouseover)="onMouseOver($event)"></div>
 </bla-overview-dialog>
+
+<div class="form-group row">
+  <label class="col-sm-3 col-form-label" for="sportsYearDropdown">
+    <span>{{ 'Sportjahr'  }}</span>
+  </label>
+  <div class="col-sm-9">
+    <select id="sportsYearDropdown"
+            class="form-control">
+      <option *ngFor="let year of [2026, 2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016]" [value]="year">
+        {{ year }}
+      </option>
+    </select>
+  </div>
+</div>

--- a/bogenliga/src/app/modules/verwaltung/services/dsb-mannschaft-data-provider.service.ts
+++ b/bogenliga/src/app/modules/verwaltung/services/dsb-mannschaft-data-provider.service.ts
@@ -173,13 +173,43 @@ export class DsbMannschaftDataProviderService extends DataProviderService {
       // sign in success -> resolve promise
       // sign in failure -> reject promise with result
       return new Promise((resolve, reject) => {
-        this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('byVereinsID/' + id +"/"+ sportjahr).build())
+        this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('byVereinsID/' + id).build() + '?sportjahr=' + sportjahr)
           .then((data: VersionedDataTransferObject[]) => {
 
             resolve({result: RequestResult.SUCCESS, payload: fromPayloadArray(data)});
 
           }, (error: HttpErrorResponse) => {
 
+            if (error.status === 0) {
+              reject({result: RequestResult.CONNECTION_PROBLEM});
+            } else {
+              reject({result: RequestResult.FAILURE});
+            }
+          });
+      });
+    }
+  }
+
+  public findAllSportjahre(): Promise<BogenligaResponse<number[]>> {
+    if (this.onOfflineService.isOffline()) {
+      return new Promise((resolve, reject) => {
+        db.mannschaftTabelle.toArray()
+          .then(data => {
+            const jahre: number[] = data
+              .map(m => m.sportjahr)
+              .filter(j => j != null)
+              .filter((j, i, arr) => arr.indexOf(j) === i)
+              .sort((a, b) => b - a);
+            resolve({result: RequestResult.SUCCESS, payload: jahre});
+          })
+          .catch(() => reject({result: RequestResult.FAILURE}));
+      });
+    } else {
+      return new Promise((resolve, reject) => {
+        this.restClient.GET<number[]>(new UriBuilder().fromPath(this.getUrl()).path('sportjahre').build())
+          .then((data: number[]) => {
+            resolve({result: RequestResult.SUCCESS, payload: data});
+          }, (error: HttpErrorResponse) => {
             if (error.status === 0) {
               reject({result: RequestResult.CONNECTION_PROBLEM});
             } else {

--- a/bogenliga/src/app/modules/verwaltung/services/dsb-mannschaft-data-provider.service.ts
+++ b/bogenliga/src/app/modules/verwaltung/services/dsb-mannschaft-data-provider.service.ts
@@ -147,6 +147,49 @@ export class DsbMannschaftDataProviderService extends DataProviderService {
       });
     }
   }
+
+  public findAllByVereinsIdAndSportjahr(id: string | number, sportjahr : number): Promise<BogenligaResponse<DsbMannschaftDO[]>> {
+    if (this.onOfflineService.isOffline()) {
+      console.log('Choosing offline way for findall mannschaften by vereinsid and sportsjahr');
+      let dsbMannschaften: DsbMannschaftDO[];
+      return new Promise((resolve, reject) => {
+        db.transaction('rw', db.mannschaftTabelle, db.vereinTabelle, (tx) => {
+          let vereine: OfflineVerein[];
+          db.vereinTabelle.toArray()
+            .then((v) => {vereine = v; });
+          db.mannschaftTabelle.where('vereinId').equals(id).toArray()
+            .then((data) => {
+              const gefilterteDaten = data.filter(m => m.sportjahr === sportjahr);
+              dsbMannschaften = mannschaftDOfromOfflineArray(gefilterteDaten, vereine);
+            });
+        })
+          .then( () => {
+            resolve({result: RequestResult.SUCCESS, payload: dsbMannschaften});
+          }, () => reject({result: RequestResult.FAILURE}));
+
+      });
+    } else {
+      // return promise
+      // sign in success -> resolve promise
+      // sign in failure -> reject promise with result
+      return new Promise((resolve, reject) => {
+        this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('byVereinsID/' + id +"/"+ sportjahr).build())
+          .then((data: VersionedDataTransferObject[]) => {
+
+            resolve({result: RequestResult.SUCCESS, payload: fromPayloadArray(data)});
+
+          }, (error: HttpErrorResponse) => {
+
+            if (error.status === 0) {
+              reject({result: RequestResult.CONNECTION_PROBLEM});
+            } else {
+              reject({result: RequestResult.FAILURE});
+            }
+          });
+      });
+    }
+  }
+
   public findAllVerAndWettByMannschaftId(id: string | number): Promise<BogenligaResponse<DsbMannschaftDO[]>> {
     // return promise
     // sign in success -> resolve promise

--- a/bogenliga/src/assets/i18n/de.json
+++ b/bogenliga/src/assets/i18n/de.json
@@ -1023,6 +1023,12 @@
         "DELETE": "Löschen"
       },
       "TABLE": {
+        "DROPDOWN": {
+          "SPORTJAHR": {
+            "LABEL": "Sportjahr",
+            "ALL": "Alle"
+          }
+        },
         "HEADERS": {
           "ID": "ID",
           "MANNSCHAFTSNAME": "Name",

--- a/bogenliga/src/assets/i18n/en.json
+++ b/bogenliga/src/assets/i18n/en.json
@@ -1038,6 +1038,12 @@
           "DELETE": "Delete"
         },
         "TABLE": {
+          "DROPDOWN": {
+            "SPORTJAHR": {
+              "LABEL": "Sport Year",
+              "ALL": "All"
+            }
+          },
           "HEADERS": {
             "ID": "ID",
             "MANNSCHAFTSNAME": "Name",


### PR DESCRIPTION
Sportjahr-Dropdown: Backend-Integration und vereinsspezifische Jahresfilterung 
  - URL-Fix in findAllByVereinsIdAndSportjahr: Sportjahr wird jetzt korrekt als
    Query-Parameter (?sportjahr=) übergeben statt als Pfad-Segment                               
   
  - Neue Methode findAllSportjahre() in DsbMannschaftDataProviderService:
    ruft GET /v1/dsbmannschaft/sportjahre auf (online) bzw. extrahiert
    eindeutige Sportjahre direkt aus der IndexedDB (offline)

  - loadSportjahre() überarbeitet: statt clientseitiger Extraktion aus den
    Mannschaftsdaten werden jetzt alle globalen Jahre vom Backend geholt und
    anschließend vereinsspezifisch gefiltert - nur Jahre ins Dropdown, in
    denen der Verein wirklich Mannschaften hat (parallele Prüfanfragen)

  - "Alle"-Option lädt jetzt korrekt alle Mannschaften des Vereins:
    parallele Requests für jedes verfügbare Sportjahr plus Warteschlange
    (byWarteschlangeID/) für Mannschaften ohne Sportjahr, gefiltert nach
    vereinId - da das Backend keinen jahresübergreifenden Endpunkt für
    einen einzelnen Verein anbietet

  - "Alle" ist beim Seitenladen als Standard vorausgewählt (selectedSportjahr = null)