### PR TITLE
Allow adding team members without league assignment

### DIFF
--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/schuetzen/schuetzen.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/schuetzen/schuetzen.component.ts
@@ -1,7 +1,7 @@
 import {Component, Input, OnInit} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
-import {ButtonType, CommonComponentDirective, toTableRows} from '../../../../../../shared/components';
-import {BogenligaResponse} from '../../../../../../shared/data-provider';
+import {ButtonType, CommonComponentDirective, toTableRows} from '@shared/components';
+import {BogenligaResponse} from '@shared/data-provider';
 import {
   Notification,
   NotificationOrigin,
@@ -9,8 +9,8 @@ import {
   NotificationSeverity,
   NotificationType,
   NotificationUserAction
-} from '../../../../../../shared/services/notification';
-import {DsbMitgliedDO} from '../../../../../types/dsb-mitglied-do.class';
+} from '@shared/services';
+import {DsbMitgliedDO} from '@verwaltung/types/dsb-mitglied-do.class';
 import {SCHUETZE_TABLE_CONFIG, SCHUETZEN_CONFIG} from './schuetzen.config';
 import {DsbMannschaftDO} from '@verwaltung/types/dsb-mannschaft-do.class';
 import {DsbMannschaftDataProviderService} from '@verwaltung/services/dsb-mannschaft-data-provider.service';

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/schuetzen/schuetzen.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/schuetzen/schuetzen.component.ts
@@ -77,17 +77,17 @@ export class SchuetzenComponent extends CommonComponentDirective implements OnIn
   private sessionHandling: SessionHandling;
 
   constructor(private mannschaftProvider: DsbMannschaftDataProviderService,
-    private dsbMitgliedProvider: DsbMitgliedDataProviderService,
-    private mannschaftMitgliedProvider: MannschaftsmitgliedDataProviderService,
-    private vereineProvider: VereinDataProviderService,
-    private lizenzProvider: LizenzDataProviderService,
-    private regionProvider: RegionDataProviderService,
-    private wettkampfProvider: WettkampfDataProviderService,
-    private router: Router,
-    private route: ActivatedRoute,
-    private onOfflineService: OnOfflineService,
-    private notificationService: NotificationService,
-    private currentUserService: CurrentUserService) {
+              private dsbMitgliedProvider: DsbMitgliedDataProviderService,
+              private mannschaftMitgliedProvider: MannschaftsmitgliedDataProviderService,
+              private vereineProvider: VereinDataProviderService,
+              private lizenzProvider: LizenzDataProviderService,
+              private regionProvider: RegionDataProviderService,
+              private wettkampfProvider: WettkampfDataProviderService,
+              private router: Router,
+              private route: ActivatedRoute,
+              private onOfflineService: OnOfflineService,
+              private notificationService: NotificationService,
+              private currentUserService: CurrentUserService) {
     super();
     this.sessionHandling = new SessionHandling(this.currentUserService, this.onOfflineService);
   }
@@ -201,6 +201,12 @@ export class SchuetzenComponent extends CommonComponentDirective implements OnIn
       this.sendSaveRequest('MANAGEMENT.SCHUETZE_HINZUFUEGEN.NOTIFICATION.SAVE', null);
       return;
     }
+
+    if (this.currentMannschaft.veranstaltungId === null || this.currentMannschaft.veranstaltungId === undefined) {
+      this.sendSaveRequest('MANAGEMENT.SCHUETZE_HINZUFUEGEN.NOTIFICATION.SAVE', null);
+      return;
+    }
+
     // get Lizenzen of this member
     this.lizenzProvider.findByDsbMitgliedId(memberId)
         .then((lizenzResponse: BogenligaResponse<LizenzDO[]>) => {
@@ -289,9 +295,8 @@ export class SchuetzenComponent extends CommonComponentDirective implements OnIn
                     this.sendSaveRequest('MANAGEMENT.SCHUETZE_HINZUFUEGEN.NOTIFICATION.SAVE', null);
                   }
                 } else {
-
-                  this.showAddedMemberNotification('MANAGEMENT.SCHUETZE_HINZUFUEGEN.NOTIFICATION.NOWETTKAEMPFE');
-                  console.log('Keine Wettkaempfe gefunden. Bitte stelle sicher das die Liga der Mannschaft Wettkampfe beinhaltet.');
+                  this.sendSaveRequest('MANAGEMENT.SCHUETZE_HINZUFUEGEN.NOTIFICATION.SAVE', null);
+                  console.log('Keine Wettkaempfe gefunden. Mannschaftsmitglied wird ohne Lizenzpruefung gespeichert.');
                 }
 
 


### PR DESCRIPTION
This change allows team members to be added even when a team has no assigned league/event or no match days yet. License creation still runs when the required event and match data is available, but missing license data no longer blocks member assignment.