### PR TITLE
#2082 anzeige meldedeadline

### DIFF
--- a/bogenliga/src/app/modules/vereine/components/mannschaft/mannschaft/mannschaft.component.ts
+++ b/bogenliga/src/app/modules/vereine/components/mannschaft/mannschaft/mannschaft.component.ts
@@ -4,7 +4,7 @@ import {CommonComponentDirective} from '@shared/components';
 import {ActivatedRoute, Router} from '@angular/router';
 import {BogenligaResponse} from '@shared/data-provider';
 import {DsbMannschaftDataProviderService} from '@verwaltung/services/dsb-mannschaft-data-provider.service';
-import {DsbMannschaftDTO} from '@verwaltung/types/datatransfer/dsb-mannschaft-dto.class';
+import {DsbMannschaftDO} from '@verwaltung/types/dsb-mannschaft-do.class';
 import {VereinDTO} from '@verwaltung/types/datatransfer/verein-dto.class';
 import {MANNSCHAFT_CONFIG, MANNSCHAFTEN_TABLE_CONFIG} from './mannschaft.config';
 import {TableRow} from '@shared/components/tables/types/table-row.class';
@@ -48,7 +48,7 @@ export class MannschaftComponent extends CommonComponentDirective implements OnI
     super();
   }
   public verein: VereinDTO | null = null;
-  public mannschaft: DsbMannschaftDTO = new DsbMannschaftDTO();
+  public mannschaft: DsbMannschaftDO = new DsbMannschaftDO();
   public rows: TableRow[] | null = null;
   public loadingTable: boolean;
   public config = MANNSCHAFT_CONFIG;
@@ -87,7 +87,7 @@ export class MannschaftComponent extends CommonComponentDirective implements OnI
   loadMannschaftData(): void {
     this.loading = true;
     this.mannschaftDataProvider.findById(this.mannschaftId)
-      .then((response: BogenligaResponse<DsbMannschaftDTO>) => {
+      .then((response: BogenligaResponse<DsbMannschaftDO>) => {
         this.mannschaft = response.payload!;
         if (this.vereinId !== this.mannschaft.vereinId) {
           this.showMannschaftNotFoundNotification();
@@ -96,7 +96,7 @@ export class MannschaftComponent extends CommonComponentDirective implements OnI
         this.loading = false;
         this.loadWettkampf();
       })
-      .catch((response: BogenligaResponse<DsbMannschaftDTO>) => {
+      .catch((response: BogenligaResponse<DsbMannschaftDO>) => {
         console.error(response);
         this.loading = false;
         this.showMannschaftNotFoundNotification();

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.ts
@@ -662,15 +662,20 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
         .then((response: BogenligaResponse<VeranstaltungDTO>) => {
           if (response.payload && response.payload.name) {
             mannschaft.veranstaltungName = response.payload.name;
+            const raw = response.payload.meldeDeadline;
+            mannschaft.meldeDeadline = raw ? new Date(raw).toLocaleDateString('de-DE') : '—';
           } else {
             mannschaft.veranstaltungName = 'Unknown';
+            mannschaft.meldeDeadline = '—';
           }
         })
         .catch(() => {
           mannschaft.veranstaltungName = '';
+          mannschaft.meldeDeadline = '—';
         });
     } else {
       mannschaft.veranstaltungName = 'Not Specified';
+      mannschaft.meldeDeadline = '—';
     }
     mannschaft.name = this.currentVerein.name + ' ' + mannschaft.nummer + '.Mannschaft';
   }

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.config.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.config.ts
@@ -24,6 +24,11 @@ export const VEREIN_DETAIL_TABLE_CONFIG: TableConfig = {
         width:          20,
       },
       {
+        translationKey: 'MANAGEMENT.VEREIN_DETAIL.TABLE.HEADERS.MELDEDEADLINE',
+        propertyName:   'meldeDeadline',
+        width:          20,
+      },
+      {
         translationKey: 'MANAGEMENT.VEREIN_DETAIL.TABLE.HEADERS.SPORTJAHR',
         propertyName:   'sportjahr',
         width:          20,

--- a/bogenliga/src/app/modules/verwaltung/mapper/mannschaft-offline-mapper.ts
+++ b/bogenliga/src/app/modules/verwaltung/mapper/mannschaft-offline-mapper.ts
@@ -71,6 +71,7 @@ export function mannschaftDOfromOffline(m: OfflineMannschaft, vereine: OfflineVe
     sportjahr:         m.sportjahr,
     veranstaltungId:   m.veranstaltungId,
     veranstaltungName: '',
+    meldeDeadline:     '',
     vereinId:          m.vereinId,
     version:           m.version
   };

--- a/bogenliga/src/app/modules/verwaltung/types/datatransfer/dsb-mannschaft-dto.class.ts
+++ b/bogenliga/src/app/modules/verwaltung/types/datatransfer/dsb-mannschaft-dto.class.ts
@@ -11,6 +11,7 @@ export class DsbMannschaftDTO implements DataTransferObject {
   sortierung: number;
   sportjahr: number;
   veranstaltungName: string;
+  meldeDeadline: string;
   ligaId: number;
   wettkampfTag: string;
   wettkampfOrtsname: string;

--- a/bogenliga/src/app/modules/verwaltung/types/datatransfer/dsb-mannschaft-dto.class.ts
+++ b/bogenliga/src/app/modules/verwaltung/types/datatransfer/dsb-mannschaft-dto.class.ts
@@ -11,7 +11,7 @@ export class DsbMannschaftDTO implements DataTransferObject {
   sortierung: number;
   sportjahr: number;
   veranstaltungName: string;
-  meldeDeadline: string;
+  //meldeDeadline: string;
   ligaId: number;
   wettkampfTag: string;
   wettkampfOrtsname: string;

--- a/bogenliga/src/app/modules/verwaltung/types/dsb-mannschaft-do.class.ts
+++ b/bogenliga/src/app/modules/verwaltung/types/dsb-mannschaft-do.class.ts
@@ -9,6 +9,7 @@ export class DsbMannschaftDO implements VersionedDataObject {
   benutzerId: number;
   veranstaltungId: number;
   veranstaltungName: string;
+  meldeDeadline: string;
   name: string;
   sortierung: number;
   sportjahr: number;

--- a/bogenliga/src/assets/i18n/de.json
+++ b/bogenliga/src/assets/i18n/de.json
@@ -1027,7 +1027,8 @@
           "ID": "ID",
           "MANNSCHAFTSNAME": "Name",
           "SPORTJAHR": "Sportjahr",
-          "LIGA": "Liga"
+          "LIGA": "Liga",
+          "MELDEDEADLINE": "Meldedeadline"
         }
       },
       "NOTIFICATION": {

--- a/bogenliga/src/assets/i18n/en.json
+++ b/bogenliga/src/assets/i18n/en.json
@@ -1042,7 +1042,8 @@
             "ID": "ID",
             "MANNSCHAFTSNAME": "Name",
             "SPORTJAHR": "Year",
-            "LIGA": "League"
+            "LIGA": "League",
+            "MELDEDEADLINE": "Registration Deadline"
           }
         },
         "NOTIFICATION": {


### PR DESCRIPTION
Zusammenfassung                                                                                                                                                                                        
                                                                                                                                                                                                         
  In der Vereinsdetailseite wird in der Mannschaftsübersichtstabelle nun pro Mannschaft die zugehörige Meldedeadline angezeigt. Das Datum wird aus der verknüpften Veranstaltung geladen und im deutschen
   Format (dd.mm.yyyy) dargestellt.                                                                                                                                                                      
   
  Änderungen                                                                                                                                                                                             
                  
  Neue Tabellenspalte
  In verein-detail.config.ts wurde eine neue Spalte „Meldedeadline" zwischen den Spalten „Liga" und „Sportjahr" ergänzt. Übersetzungsschlüssel wurden in de.json ("Meldedeadline") und en.json
  ("Registration Deadline") hinterlegt.

  Datenbeschaffung
  Das Backend liefert meldeDeadline nicht als Teil der Mannschaftsdaten. Da in addTableAttributes() bereits ein API-Call zu veranstaltungsProvider.findById() für jeden Mannschaftseintrag gemacht wurde,
   wurde dieser bestehende Call genutzt, um meldeDeadline aus der Veranstaltungs-Response mitzulesen — ohne zusätzlichen API-Call. Das ISO-Datum wird mit toLocaleDateString('de-DE') in das Format
  dd.mm.yyyy umgewandelt. Ist kein Datum gesetzt, wird — angezeigt.

  Datenmodell
  DsbMannschaftDO wurde um das Anzeigefeld meldeDeadline: string erweitert. Der Offline-Mapper mannschaft-offline-mapper.ts wurde entsprechend ergänzt, um den TypeScript-Compiler-Fehler durch das neue
  Pflichtfeld zu beheben.

  Typkorrektur
  In MannschaftComponent (vereine-Modul) wurden fehlerhafte Typannotationen von DsbMannschaftDTO auf DsbMannschaftDO korrigiert, da findById() im Service bereits DsbMannschaftDO zurückgibt.