### PR TITLE
fix(#2183): fix session expired popup on login failure and add cypress e2e test

### DIFF
--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/anonyme-user/login-fehlermeldung.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/anonyme-user/login-fehlermeldung.cy.js
@@ -1,0 +1,20 @@
+describe('Login Fehlermeldung Test', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:4200/#/user/login');
+  });
+
+  it('sollte eine Fehlermeldung im Formular anzeigen, wenn das Passwort falsch ist', () => {
+    cy.get('#loginEmail').type('falsche@email.de');
+    cy.get('#loginPassword').type('FalschesPasswort123!');
+
+    cy.get('#loginButton').click();
+
+    cy.get('bla-alert')
+      .filter(':contains("Die Anmeldedaten sind falsch.")')
+      .should('exist')
+      .and('be.visible');
+
+    cy.get('#loginEmail').should('have.class', 'is-invalid');
+    cy.get('#loginPassword').should('have.class', 'is-invalid');
+  });
+});

--- a/bogenliga/src/app/modules/shared/data-provider/interceptors/error-interceptor.class.ts
+++ b/bogenliga/src/app/modules/shared/data-provider/interceptors/error-interceptor.class.ts
@@ -1,6 +1,6 @@
 import {HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
 import {Injectable} from '@angular/core';
-import {Observable} from 'rxjs';
+import {Observable, throwError} from 'rxjs';
 import {catchError, retry} from 'rxjs/operators';
 import {ErrorHandlingService} from '../../services/error-handling';
 import {Router} from '@angular/router';
@@ -24,11 +24,16 @@ export class ErrorInterceptor implements HttpInterceptor {
     return next.handle(request)
 
                .pipe(
-                 // add retries
-                 retry(MAX_RETRIES),
+                 // add retries - avoid retrying login requests
+                 retry(request.url.includes('v1/user/signin') ? 0 : MAX_RETRIES),
                  // add error handling
                  catchError(
                    (error: any, caught: Observable<HttpEvent<any>>) => {
+
+                     // Bypass global error handling for login to let LoginComponent handle the UI natively
+                     if (request.url.includes('v1/user/signin')) {
+                       return throwError(error);
+                     }
 
                      // handle connection (0), client (4xx), server (5xx) and custom error codes (9xx)
                      // if it is a connection error, it could be a masked error indicated by an expired session token


### PR DESCRIPTION
Bugfix: Login-Fehlermeldung & Session-Popup behoben

Bei einer falschen Passworteingabe ploppte fälschlicherweise das globale Pop-up "Sitzung abgelaufen" auf, statt der nativen, roten Fehlermeldung der Login-Komponente.

Ursache:
Der globale `ErrorInterceptor` hat den HTTP-Status `401` blind für alle URLs abgefangen und pauschal als abgelaufene Session interpretiert.

Lösung
1. Bypass im Interceptor: Wenn der Fehler vom `/signin`-Endpoint kommt, wird er nun sofort mit `return throwError(error);` unverändert weitergeworfen. Dadurch übernimmt die `LoginComponent` wie gewohnt nativ das UI.
2. Bedingtes Retry: Bei Login-Anfragen wird der `retry`-Wert auf `0` gesetzt, um das Backend bei Tippfehlen nicht mit Requests zu spammen.
3. E2E-Testing: Ein neuer Cypress-Test (`login-fehlermeldung.cy.js`) wurde hinzugefügt und läuft erfolgreich.