### PR TITLE
#2144

### DIFF
--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.html
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.html
@@ -86,4 +86,27 @@
       Anzeige hinzufügen
     </button>
   </div>
+
+  <!-- Overlay (dunkler Hintergrund) -->
+  <div class="id-popup-overlay" *ngIf="IdGeneratePopup"></div>
+
+  <!-- Popup Fenster (draggable) -->
+  <div class="id-popup" *ngIf="IdGeneratePopup" [ngStyle]="{'left.px': popupPosition.x, 'top.px': popupPosition.y}">
+
+    <!-- Header (Titelleiste zum Verschieben) -->
+    <div class="id-popup-header" (mousedown)="startDrag($event)">
+      <div class="id-popup-title">Generierte ID</div>
+      <button class="id-popup-close" (click)="closeGeneratedIdPopup()">✕</button>
+    </div>
+
+    <!-- Body (Inhalt) -->
+    <div class="id-popup-body">
+      <div class="id-display">{{ generatedId || 'XXXX' }}</div>
+
+      <div class="id-popup-actions">
+        <button class="action-btn action-btn-primary copy-button" (click)="copyGeneratedId()">Kopieren</button>
+      </div>
+    </div>
+
+  </div>
 </div>

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.html
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.html
@@ -65,6 +65,13 @@
 
   </div>
   <button
+    class="action-btn action-btn-success id-button"
+    (click)="showGeneratedID()"
+    title="ID generieren">
+    <span class="action-btn-circle">+</span>
+    ID generieren
+  </button>
+  <button
     class="action-btn action-btn-success update-button"
     (click)="updateDisplay()"
     title="Anzeige Übernehmen">

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.html
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.html
@@ -87,25 +87,32 @@
     </button>
   </div>
 
-  <!-- Overlay (dunkler Hintergrund) -->
-  <div class="id-popup-overlay" *ngIf="IdGeneratePopup"></div>
-
-  <!-- Popup Fenster (draggable) -->
+  <!-- Dunkles Overlay wie bei Fehlermeldung Popups-->
   <div class="id-popup" *ngIf="IdGeneratePopup" [ngStyle]="{'left.px': popupPosition.x, 'top.px': popupPosition.y}">
 
     <!-- Header (Titelleiste zum Verschieben) -->
     <div class="id-popup-header" (mousedown)="startDrag($event)">
-      <div class="id-popup-title">Generierte ID</div>
-      <button class="id-popup-close" (click)="closeGeneratedIdPopup()">✕</button>
+      <div class="id-popup-title">
+        Generierte ID
+      </div>
+      <button class="id-popup-close"
+              (click)="closeGeneratedIdPopup()">
+                ✕
+      </button>
     </div>
 
     <!-- Body (Inhalt) -->
     <div class="id-popup-body">
       <div class="id-display">{{ generatedId || 'XXXX' }}</div>
+    </div>
 
-      <div class="id-popup-actions">
-        <button class="action-btn action-btn-primary copy-button" (click)="copyGeneratedId()">Kopieren</button>
-      </div>
+    <!-- Footer mit Button rechts -->
+    <div class="id-popup-footer">
+      <button class="action-btn action-btn-primary copy-button"
+              (click)="copyGeneratedId()">
+              <span class="action-btn-circle">+</span>
+              Kopieren
+      </button>
     </div>
 
   </div>

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.html
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.html
@@ -65,13 +65,6 @@
 
   </div>
   <button
-    class="action-btn action-btn-success id-button"
-    (click)="showGeneratedID()"
-    title="ID generieren">
-    <span class="action-btn-circle">+</span>
-    ID generieren
-  </button>
-  <button
     class="action-btn action-btn-success update-button"
     (click)="updateDisplay()"
     title="Anzeige Übernehmen">
@@ -87,33 +80,4 @@
     </button>
   </div>
 
-  <!-- Dunkles Overlay wie bei Fehlermeldung Popups-->
-  <div class="id-popup" *ngIf="IdGeneratePopup" [ngStyle]="{'left.px': popupPosition.x, 'top.px': popupPosition.y}">
-
-    <!-- Header (Titelleiste zum Verschieben) -->
-    <div class="id-popup-header" (mousedown)="startDrag($event)">
-      <div class="id-popup-title">
-        Generierte ID
-      </div>
-      <button class="id-popup-close"
-              (click)="closeGeneratedIdPopup()">
-                ✕
-      </button>
-    </div>
-
-    <!-- Body (Inhalt) -->
-    <div class="id-popup-body">
-      <div class="id-display">{{ generatedId || 'XXXX' }}</div>
-    </div>
-
-    <!-- Footer mit Button rechts -->
-    <div class="id-popup-footer">
-      <button class="action-btn action-btn-primary copy-button"
-              (click)="copyGeneratedId()">
-              <span class="action-btn-circle">+</span>
-              Kopieren
-      </button>
-    </div>
-
-  </div>
 </div>

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.scss
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.scss
@@ -54,12 +54,6 @@
   justify-content: center;
 }
 
-.id-button {
-  min-width: 120px;
-  height: 30px;
-  justify-content: center;
-}
-
 .display-config-section {
   background-color: #eaeaef;
   padding: 0 10px 30px;
@@ -121,87 +115,3 @@
   }
 }
 
-/* Styles für das Fenster mit der generierten ID */
-.id-popup-overlay {
-  position: fixed;
-  left: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.25);
-  z-index: 2000;
-}
-
-.id-popup {
-  position: fixed;
-  width: 320px;
-  height: auto;
-  background: white;
-  border-radius: 8px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
-  z-index: 2100;
-  user-select: none;
-}
-
-.id-popup-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 10px 12px;
-  cursor: move;
-  border-bottom: 1px solid #eee;
-  background: #f7f7f8;
-  border-top-left-radius: 8px;
-  border-top-right-radius: 8px;
-}
-
-.id-popup-title {
-  font-weight: 600;
-  font-size: 14px;
-}
-
-.id-popup-close {
-  border: none;
-  background: transparent;
-  font-size: 16px;
-  cursor: pointer;
-  padding: 0;
-  width: 20px;
-  height: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  &:hover {
-    background: #eee;
-    border-radius: 4px;
-  }
-}
-
-.id-popup-body {
-  padding: 18px;
-  text-align: center;
-}
-
-.id-display {
-  font-size: 36px;
-  font-weight: 700;
-  letter-spacing: 2px;
-  margin-bottom: 12px;
-  font-family: monospace;
-}
-.id-popup-footer {
-  padding: 12px 18px;
-  display: flex;
-  justify-content: flex-end;
-  border-top: 1px solid #eee;
-  background: #f9f9f9;
-  border-bottom-left-radius: 8px;
-  border-bottom-right-radius: 8px;
-}
-
-  .copy-button {
-    min-width: 120px;
-    height: 30px;
-    justify-content: center;
-  }

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.scss
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.scss
@@ -54,6 +54,12 @@
   justify-content: center;
 }
 
+.id-button {
+  min-width: 120px;
+  height: 30px;
+  justify-content: center;
+}
+
 .display-config-section {
   background-color: #eaeaef;
   padding: 0 10px 30px;

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.scss
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.scss
@@ -120,3 +120,85 @@
     justify-content: center;
   }
 }
+
+/* Styles für das Fenster mit der generierten ID */
+.id-popup-overlay {
+  position: fixed;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.25);
+  z-index: 2000;
+}
+
+.id-popup {
+  position: fixed;
+  width: 320px;
+  height: auto;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  z-index: 2100;
+  user-select: none;
+}
+
+.id-popup-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 12px;
+  cursor: move;
+  border-bottom: 1px solid #eee;
+  background: #f7f7f8;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.id-popup-title {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.id-popup-close {
+  border: none;
+  background: transparent;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background: #eee;
+    border-radius: 4px;
+  }
+}
+
+.id-popup-body {
+  padding: 18px;
+  text-align: center;
+}
+
+.id-display {
+  font-size: 36px;
+  font-weight: 700;
+  letter-spacing: 2px;
+  margin-bottom: 12px;
+  font-family: monospace;
+}
+
+.id-popup-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+
+  .copy-button {
+    min-width: 120px;
+    height: 30px;
+    justify-content: center;
+  }
+}

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.scss
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.scss
@@ -190,15 +190,18 @@
   margin-bottom: 12px;
   font-family: monospace;
 }
-
-.id-popup-actions {
+.id-popup-footer {
+  padding: 12px 18px;
   display: flex;
-  gap: 10px;
-  justify-content: center;
+  justify-content: flex-end;
+  border-top: 1px solid #eee;
+  background: #f9f9f9;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
 
   .copy-button {
     min-width: 120px;
     height: 30px;
     justify-content: center;
   }
-}

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, OnDestroy} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {BogenligaResponse} from '@shared/data-provider';
 import {isNullOrUndefined} from '@shared/functions';
 import {AnzeigenDO} from '@wkdurchfuehrung/types/anzeige-do.class';
@@ -12,7 +12,7 @@ import {ActivatedRoute} from '@angular/router';
   styleUrls: ['./anzeige-manager.component.scss']
 })
 
-export class AnzeigeManagerComponent implements OnInit, OnDestroy {
+export class AnzeigeManagerComponent implements OnInit {
   /*
   *  AnzeigenProviderService hat oben das hier:
   *   @Injectable({
@@ -27,36 +27,6 @@ export class AnzeigeManagerComponent implements OnInit, OnDestroy {
 
   public wettkampfId: number;
 
-  // Für das Fenster der generierten ID
-  public IdGeneratePopup = false;
-  public generatedId = '';
-  public popupPosition = {x: 120, y: 120};
-
-  private isDragging = false;
-  private dragOffsetX = 0;
-  private dragOffsetY = 0;
-
-  // Fenster mit dem Mauszeiger ist bewegbar
-  private onWindowMouseMove = (ev: MouseEvent) => {
-    if (!this.isDragging) {
-      return;
-    }
-    this.popupPosition.x = ev.clientX - this.dragOffsetX;
-    this.popupPosition.y = ev.clientY - this.dragOffsetY;
-    if (this.popupPosition.x < 0) {
-      this.popupPosition.x = 0;
-    }
-    if (this.popupPosition.y < 0) {
-      this.popupPosition.y = 0;
-    }
-  }
-
-  private onWindowMouseUp = (_ev: MouseEvent) => {
-    if (this.isDragging) {
-      this.isDragging = false;
-    }
-  }
-
   constructor(private anzeigenProvider: AnzeigenProviderService, private route: ActivatedRoute) {}
 
   ngOnInit(): void {
@@ -64,14 +34,8 @@ export class AnzeigeManagerComponent implements OnInit, OnDestroy {
     this.route.paramMap.subscribe((params) => {
       this.wettkampfId = parseInt(params.get('selectedWettkampfId'), 10);
     });
-    window.addEventListener('mousemove', this.onWindowMouseMove);
-    window.addEventListener('mouseup', this.onWindowMouseUp);
   }
 
-  ngOnDestroy(): void {
-    window.removeEventListener('mousemove', this.onWindowMouseMove);
-    window.removeEventListener('mouseup', this.onWindowMouseUp);
-  }
 
 
 
@@ -132,48 +96,5 @@ export class AnzeigeManagerComponent implements OnInit, OnDestroy {
   public async showGeneratedID(): Promise<void> {
     const response = await this.anzeigenProvider.getNewPhysischeBildschirmID();
     this.generatedId = '' + response.payload;
-    this.IdGeneratePopup = true;
-    this.popupPosition = {x: 120, y: 120};
-  }
-
-  public closeGeneratedIdPopup(): void {
-    this.IdGeneratePopup = false;
-    this.isDragging = false;
-  }
-
-  public startDrag(event: MouseEvent): void {
-    if (event.button !== 0) {
-      return;
-    }
-    this.isDragging = true;
-    this.dragOffsetX = event.clientX - this.popupPosition.x;
-    this.dragOffsetY = event.clientY - this.popupPosition.y;
-    event.preventDefault();
-  }
-
-  public copyGeneratedId(): void {
-    if (!this.generatedId) {
-      alert('Es ist noch keine ID vorhanden.');
-      return;
-    }
-
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(this.generatedId).then(() => {
-        alert('ID kopiert');
-      }, () => {
-        alert('Kopieren fehlgeschlagen');
-      });
-    } else {
-      const ta = document.createElement('textarea');
-      document.body.appendChild(ta);
-      ta.select();
-      try {
-        document.execCommand('copy');
-        alert('ID kopiert');
-      } catch (e) {
-        alert('Kopieren fehlgeschlagen');
-      }
-      document.body.removeChild(ta);
-    }
   }
 }

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.ts
@@ -3,7 +3,7 @@ import {BogenligaResponse} from '@shared/data-provider';
 import {isNullOrUndefined} from '@shared/functions';
 import {AnzeigenDO} from '@wkdurchfuehrung/types/anzeige-do.class';
 import {AnzeigenProviderService} from '@wkdurchfuehrung/services/anzeigen-provider.service';
-import {ActivatedRoute} from '@angular/router';
+import {ActivatedRoute, Router} from '@angular/router';
 
 
 @Component({
@@ -27,7 +27,7 @@ export class AnzeigeManagerComponent implements OnInit {
 
   public wettkampfId: number;
 
-  constructor(private anzeigenProvider: AnzeigenProviderService, private route: ActivatedRoute) {}
+  constructor(private anzeigenProvider: AnzeigenProviderService, private route: ActivatedRoute, private router: Router) {}
 
   ngOnInit(): void {
     // Holt den in der wkdurchfuehrung.routing.ts definierten Parameter aus der URL
@@ -35,9 +35,6 @@ export class AnzeigeManagerComponent implements OnInit {
       this.wettkampfId = parseInt(params.get('selectedWettkampfId'), 10);
     });
   }
-
-
-
 
   public nextMatch(): void {
     this.currentMatch++;
@@ -93,8 +90,9 @@ export class AnzeigeManagerComponent implements OnInit {
     });
   }
 
-  public async showGeneratedID(): Promise<void> {
-    const response = await this.anzeigenProvider.getNewPhysischeBildschirmID();
-    this.generatedId = '' + response.payload;
+  public navigateToScreen(): void {
+    this.router.navigate(['/wkdurchfuehrung/anzeige-physische-id', this.wettkampfId]);
   }
+
+
 }

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, OnDestroy} from '@angular/core';
 import {BogenligaResponse} from '@shared/data-provider';
 import {isNullOrUndefined} from '@shared/functions';
 import {AnzeigenDO} from '@wkdurchfuehrung/types/anzeige-do.class';
@@ -12,7 +12,7 @@ import {ActivatedRoute} from '@angular/router';
   styleUrls: ['./anzeige-manager.component.scss']
 })
 
-export class AnzeigeManagerComponent implements OnInit {
+export class AnzeigeManagerComponent implements OnInit, OnDestroy {
   /*
   *  AnzeigenProviderService hat oben das hier:
   *   @Injectable({
@@ -27,6 +27,36 @@ export class AnzeigeManagerComponent implements OnInit {
 
   public wettkampfId: number;
 
+  // Für das Fenster der generierten ID
+  public IdGeneratePopup = false;
+  public generatedId = 'test';
+  public popupPosition = {x: 120, y: 120};
+
+  private isDragging = false;
+  private dragOffsetX = 0;
+  private dragOffsetY = 0;
+
+  // Fenster mit dem Mauszeiger ist bewegbar
+  private onWindowMouseMove = (ev: MouseEvent) => {
+    if (!this.isDragging) {
+      return;
+    }
+    this.popupPosition.x = ev.clientX - this.dragOffsetX;
+    this.popupPosition.y = ev.clientY - this.dragOffsetY;
+    if (this.popupPosition.x < 0) {
+      this.popupPosition.x = 0;
+    }
+    if (this.popupPosition.y < 0) {
+      this.popupPosition.y = 0;
+    }
+  }
+
+  private onWindowMouseUp = (_ev: MouseEvent) => {
+    if (this.isDragging) {
+      this.isDragging = false;
+    }
+  }
+
   constructor(private anzeigenProvider: AnzeigenProviderService, private route: ActivatedRoute) {}
 
   ngOnInit(): void {
@@ -34,7 +64,16 @@ export class AnzeigeManagerComponent implements OnInit {
     this.route.paramMap.subscribe((params) => {
       this.wettkampfId = parseInt(params.get('selectedWettkampfId'), 10);
     });
+    window.addEventListener('mousemove', this.onWindowMouseMove);
+    window.addEventListener('mouseup', this.onWindowMouseUp);
   }
+
+  ngOnDestroy(): void {
+    window.removeEventListener('mousemove', this.onWindowMouseMove);
+    window.removeEventListener('mouseup', this.onWindowMouseUp);
+  }
+
+
 
   public nextMatch(): void {
     this.currentMatch++;
@@ -90,5 +129,50 @@ export class AnzeigeManagerComponent implements OnInit {
     });
   }
 
-  public showGeneratedID(): void{}
+  public showGeneratedID(): void {
+    this.IdGeneratePopup = true;
+    this.popupPosition = {x: 120, y: 120};
+  }
+
+  public closeGeneratedIdPopup(): void {
+    this.IdGeneratePopup = false;
+    this.isDragging = false;
+  }
+
+  public startDrag(event: MouseEvent): void {
+    if (event.button !== 0) {
+      return;
+    }
+    this.isDragging = true;
+    this.dragOffsetX = event.clientX - this.popupPosition.x;
+    this.dragOffsetY = event.clientY - this.popupPosition.y;
+    event.preventDefault();
+  }
+
+  public copyGeneratedId(): void {
+    if (!this.generatedId) {
+      alert('Es ist noch keine ID vorhanden.');
+      return;
+    }
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(this.generatedId).then(() => {
+        alert('ID kopiert');
+      }, () => {
+        alert('Kopieren fehlgeschlagen');
+      });
+    } else {
+      const ta = document.createElement('textarea');
+      ta.value = this.generatedId;
+      document.body.appendChild(ta);
+      ta.select();
+      try {
+        document.execCommand('copy');
+        alert('ID kopiert');
+      } catch (e) {
+        alert('Kopieren fehlgeschlagen');
+      }
+      document.body.removeChild(ta);
+    }
+  }
 }

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.ts
@@ -29,7 +29,7 @@ export class AnzeigeManagerComponent implements OnInit, OnDestroy {
 
   // Für das Fenster der generierten ID
   public IdGeneratePopup = false;
-  public generatedId = this.anzeigenProvider.getNewPhysischeBildschirmID();
+  public generatedId = '';
   public popupPosition = {x: 120, y: 120};
 
   private isDragging = false;
@@ -130,6 +130,7 @@ export class AnzeigeManagerComponent implements OnInit, OnDestroy {
   }
 
   public showGeneratedID(): void {
+    this.generatedId = '' + this.anzeigenProvider.getNewPhysischeBildschirmID();
     this.IdGeneratePopup = true;
     this.popupPosition = {x: 120, y: 120};
   }
@@ -163,7 +164,6 @@ export class AnzeigeManagerComponent implements OnInit, OnDestroy {
       });
     } else {
       const ta = document.createElement('textarea');
-      ta.value = this.generatedId;
       document.body.appendChild(ta);
       ta.select();
       try {

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.ts
@@ -29,7 +29,7 @@ export class AnzeigeManagerComponent implements OnInit, OnDestroy {
 
   // Für das Fenster der generierten ID
   public IdGeneratePopup = false;
-  public generatedId = 'test';
+  public generatedId = this.anzeigenProvider.getNewPhysischeBildschirmID();
   public popupPosition = {x: 120, y: 120};
 
   private isDragging = false;

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.ts
@@ -89,4 +89,6 @@ export class AnzeigeManagerComponent implements OnInit {
         });
     });
   }
+
+  public showGeneratedID(): void{}
 }

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager/anzeige-manager.component.ts
@@ -129,8 +129,9 @@ export class AnzeigeManagerComponent implements OnInit, OnDestroy {
     });
   }
 
-  public showGeneratedID(): void {
-    this.generatedId = '' + this.anzeigenProvider.getNewPhysischeBildschirmID();
+  public async showGeneratedID(): Promise<void> {
+    const response = await this.anzeigenProvider.getNewPhysischeBildschirmID();
+    this.generatedId = '' + response.payload;
     this.IdGeneratePopup = true;
     this.popupPosition = {x: 120, y: 120};
   }

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-physische_ID/anzeige_physische_ID.component.html
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-physische_ID/anzeige_physische_ID.component.html
@@ -1,4 +1,4 @@
-<div class="screen-registration">
+<div class="screen-registration fullscreen-mode">
   <h1 class="title">BILDSCHIRM-REGISTRIERUNG</h1>
 
   <div class="code-box">

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-physische_ID/anzeige_physische_ID.component.html
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-physische_ID/anzeige_physische_ID.component.html
@@ -1,0 +1,11 @@
+<div class="screen-registration">
+  <h1 class="title">BILDSCHIRM-REGISTRIERUNG</h1>
+
+  <div class="code-box">
+    <span class="code">{{ physischeBildschirmID }}</span>
+  </div>
+
+  <p class="hint">
+    Geben Sie diesen Code in der Bildschirmverwaltung an.
+  </p>
+</div>

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-physische_ID/anzeige_physische_ID.component.scss
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-physische_ID/anzeige_physische_ID.component.scss
@@ -1,0 +1,51 @@
+.screen-registration {
+  min-height: 100vh;
+  background-color: #fff;
+  color: #000;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  text-align: center;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.title {
+  color: #005fcc;
+  font-size: 2.5rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin-bottom: 2.5rem;
+  text-transform: uppercase;
+}
+
+.code-box {
+  border: 6px solid #005fcc;
+  border-radius: 20px;
+  width: min(700px, 90vw);
+  min-height: 260px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  margin-bottom: 2rem;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.code {
+  font-size: clamp(4rem, 10vw, 8rem);
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: #000;
+}
+
+.hint {
+  font-size: 1.5rem;
+  color: #333;
+  margin: 0;
+}

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-physische_ID/anzeige_physische_ID.component.scss
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-physische_ID/anzeige_physische_ID.component.scss
@@ -1,6 +1,6 @@
 .screen-registration {
   min-height: 100vh;
-  background-color: #fff;
+  background-color: #F2F0EF;
   color: #000;
 
   display: flex;
@@ -9,43 +9,56 @@
   justify-content: center;
 
   text-align: center;
-  padding: 2rem;
+  padding: 0;
+  margin: 0;
   box-sizing: border-box;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 9999;
+
+  &.fullscreen-mode {
+    min-height: 100vh;
+    padding: 0;
+    margin: 0;
+  }
 }
 
 .title {
   color: #005fcc;
-  font-size: 2.5rem;
+  font-size: 4rem;
   font-weight: 700;
   letter-spacing: 0.08em;
-  margin-bottom: 2.5rem;
+  margin-bottom: 3rem;
   text-transform: uppercase;
 }
 
 .code-box {
-  border: 6px solid #005fcc;
+  border: 8px solid #005fcc;
   border-radius: 20px;
-  width: min(700px, 90vw);
-  min-height: 260px;
+  width: min(800px, 95vw);
+  min-height: 350px;
 
   display: flex;
   align-items: center;
   justify-content: center;
 
-  margin-bottom: 2rem;
-  padding: 2rem;
+  margin-bottom: 3rem;
+  padding: 3rem;
   box-sizing: border-box;
 }
 
 .code {
-  font-size: clamp(4rem, 10vw, 8rem);
+  font-size: clamp(6rem, 15vw, 12rem);
   font-weight: 700;
   letter-spacing: 0.12em;
   color: #000;
 }
 
 .hint {
-  font-size: 1.5rem;
+  font-size: 2rem;
   color: #333;
   margin: 0;
 }

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-physische_ID/anzeige_physische_ID.component.spec.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-physische_ID/anzeige_physische_ID.component.spec.ts
@@ -1,0 +1,89 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {BogenligaResponse, RequestResult} from '@shared/data-provider';
+import {AnzeigenProviderService} from '@wkdurchfuehrung/services/anzeigen-provider.service';
+import {AnzeigePhysischeIDComponent} from './anzeige_physische_ID.component';
+
+const successResponse = (payload: string): BogenligaResponse<string> => ({
+  result: RequestResult.SUCCESS,
+  payload
+});
+
+describe('AnzeigePhysischeIDComponent', () => {
+  let component: AnzeigePhysischeIDComponent;
+  let fixture: ComponentFixture<AnzeigePhysischeIDComponent>;
+  let anzeigenProviderMock: jasmine.SpyObj<AnzeigenProviderService>;
+
+  beforeEach(async () => {
+    anzeigenProviderMock = jasmine.createSpyObj('AnzeigenProviderService', ['getNewPhysischeBildschirmID']);
+    anzeigenProviderMock.getNewPhysischeBildschirmID.and.returnValue(Promise.resolve(successResponse('Ab1C')));
+
+    await TestBed.configureTestingModule({
+      declarations: [AnzeigePhysischeIDComponent],
+      providers: [{provide: AnzeigenProviderService, useValue: anzeigenProviderMock}],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AnzeigePhysischeIDComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('showGeneratedID should set physischeBildschirmID from provider payload', async () => {
+    await component.showGeneratedID();
+
+    expect(anzeigenProviderMock.getNewPhysischeBildschirmID).toHaveBeenCalled();
+    expect(component.physischeBildschirmID).toBe('Ab1C');
+  });
+
+  it('showGeneratedID should stringify a null payload', async () => {
+    anzeigenProviderMock.getNewPhysischeBildschirmID.and.returnValue(
+      Promise.resolve(successResponse(null)));
+
+    await component.showGeneratedID();
+
+    expect(component.physischeBildschirmID).toBe('null');
+  });
+
+  it('ngOnInit should load the id and activate fullscreen', async () => {
+    const requestFullscreenSpy = spyOn(document.documentElement, 'requestFullscreen')
+      .and.returnValue(Promise.resolve());
+
+    await component.ngOnInit();
+
+    expect(component.physischeBildschirmID).toBe('Ab1C');
+    expect(requestFullscreenSpy).toHaveBeenCalled();
+  });
+
+  it('ngOnInit should not throw when requestFullscreen rejects', async () => {
+    spyOn(document.documentElement, 'requestFullscreen')
+      .and.returnValue(Promise.reject(new Error('denied')));
+
+    await component.ngOnInit();
+
+    expect(component.physischeBildschirmID).toBe('Ab1C');
+  });
+
+  it('onEscapeKey should exit fullscreen when a fullscreen element is active', () => {
+    const exitFullscreenSpy = spyOn(document, 'exitFullscreen').and.returnValue(Promise.resolve());
+    spyOnProperty(document, 'fullscreenElement', 'get').and.returnValue(document.documentElement);
+
+    component.onEscapeKey();
+
+    expect(exitFullscreenSpy).toHaveBeenCalled();
+    expect(component.isFullscreen).toBe(false);
+  });
+
+  it('onEscapeKey should do nothing when no fullscreen element is active', () => {
+    const exitFullscreenSpy = spyOn(document, 'exitFullscreen').and.returnValue(Promise.resolve());
+    spyOnProperty(document, 'fullscreenElement', 'get').and.returnValue(null);
+
+    component.onEscapeKey();
+
+    expect(exitFullscreenSpy).not.toHaveBeenCalled();
+    expect(component.isFullscreen).toBe(true);
+  });
+});

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-physische_ID/anzeige_physische_ID.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-physische_ID/anzeige_physische_ID.component.ts
@@ -12,8 +12,8 @@ export class AnzeigePhysischeIDComponent implements OnInit {
 
   constructor(private anzeigenProvider: AnzeigenProviderService) {}
 
-  ngOnInit(): void {
-    this.showGeneratedID();
+  async ngOnInit(): Promise<void> {
+    await this.showGeneratedID();
     this.activateFullscreen();
   }
 

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-physische_ID/anzeige_physische_ID.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-physische_ID/anzeige_physische_ID.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, HostListener} from '@angular/core';
 import {AnzeigenProviderService} from '@wkdurchfuehrung/services/anzeigen-provider.service';
 
 @Component({
@@ -8,26 +8,36 @@ import {AnzeigenProviderService} from '@wkdurchfuehrung/services/anzeigen-provid
 })
 export class AnzeigePhysischeIDComponent implements OnInit {
   physischeBildschirmID = '';
+  isFullscreen = true;
 
   constructor(private anzeigenProvider: AnzeigenProviderService) {}
 
   ngOnInit(): void {
     this.showGeneratedID();
+    this.activateFullscreen();
   }
 
   public async showGeneratedID(): Promise<void> {
-    try {
       const response = await this.anzeigenProvider.getNewPhysischeBildschirmID();
-      if (response && response.payload) {
-        this.physischeBildschirmID = '' + response.payload;
-        console.log('Physische Bildschirm ID geladen:', this.physischeBildschirmID);
-      } else {
-        console.error('Keine ID in der Response erhalten');
-        this.physischeBildschirmID = 'Fehler: Keine ID';
-      }
-    } catch (error) {
-      console.error('Fehler beim Abrufen der Physische Bildschirm ID:', error);
-      this.physischeBildschirmID = 'Fehler beim Laden';
+      this.physischeBildschirmID = '' + response.payload;
+  }
+
+  private activateFullscreen(): void {
+    const element = document.documentElement;
+
+    if (element.requestFullscreen) {
+      element.requestFullscreen().catch((err) => {
+        console.warn('Vollbild-Anfrage fehlgeschlagen:', err);
+      });
     }
   }
+
+  @HostListener('document:keydown.escape')
+  onEscapeKey(): void {
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+      this.isFullscreen = false;
+    }
+  }
+
 }

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-physische_ID/anzeige_physische_ID.component.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-physische_ID/anzeige_physische_ID.component.ts
@@ -1,0 +1,33 @@
+import {Component, OnInit} from '@angular/core';
+import {AnzeigenProviderService} from '@wkdurchfuehrung/services/anzeigen-provider.service';
+
+@Component({
+  selector: 'bla-screen-registration',
+  templateUrl: './anzeige_physische_ID.component.html',
+  styleUrls: ['./anzeige_physische_ID.component.scss']
+})
+export class AnzeigePhysischeIDComponent implements OnInit {
+  physischeBildschirmID = '';
+
+  constructor(private anzeigenProvider: AnzeigenProviderService) {}
+
+  ngOnInit(): void {
+    this.showGeneratedID();
+  }
+
+  public async showGeneratedID(): Promise<void> {
+    try {
+      const response = await this.anzeigenProvider.getNewPhysischeBildschirmID();
+      if (response && response.payload) {
+        this.physischeBildschirmID = '' + response.payload;
+        console.log('Physische Bildschirm ID geladen:', this.physischeBildschirmID);
+      } else {
+        console.error('Keine ID in der Response erhalten');
+        this.physischeBildschirmID = 'Fehler: Keine ID';
+      }
+    } catch (error) {
+      console.error('Fehler beim Abrufen der Physische Bildschirm ID:', error);
+      this.physischeBildschirmID = 'Fehler beim Laden';
+    }
+  }
+}

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/index.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/index.ts
@@ -6,3 +6,4 @@ export * from './tablet-admin/tablet-admin.component';
 export * from './tableteingabe/tableteingabe.component';
 export * from './fullscreen/fullscreen.component';
 export * from './anzeige-manager/anzeige-manager.component';
+export * from './anzeige-physische_ID/anzeige_physische_ID.component';

--- a/bogenliga/src/app/modules/wkdurchfuehrung/services/anzeigen-provider.service.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/services/anzeigen-provider.service.ts
@@ -58,7 +58,7 @@ export class AnzeigenProviderService extends DataProviderService {
     }
 
   public getNewPhysischeBildschirmID(): Promise<BogenligaResponse<string>> {
-    return new Promise(((resolve, reject) => {
+    const promise: Promise<BogenligaResponse<string>> = new Promise((resolve, reject) => {
       this.restClient.GET(this.getUrl() + '/getNewPhysischeBildschirmID')
         .then((data: any) => {
           resolve({result: RequestResult.SUCCESS, payload: data.id});
@@ -69,6 +69,7 @@ export class AnzeigenProviderService extends DataProviderService {
             reject({result: RequestResult.FAILURE});
           }
         });
-    }));
+    });
+    return promise;
   }
 }

--- a/bogenliga/src/app/modules/wkdurchfuehrung/services/anzeigen-provider.service.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/services/anzeigen-provider.service.ts
@@ -59,9 +59,9 @@ export class AnzeigenProviderService extends DataProviderService {
 
   public getNewPhysischeBildschirmID(): Promise<BogenligaResponse<string>> {
     return new Promise(((resolve, reject) => {
-      this.restClient.GET(this.getUrl())
-        .then((data: string) => {
-          resolve({result: RequestResult.SUCCESS, payload: data});
+      this.restClient.GET(this.getUrl() + '/getNewPhysischeBildschirmID')
+        .then((data: any) => {
+          resolve({result: RequestResult.SUCCESS, payload: data.id});
         }, (error: HttpErrorResponse) => {
           if (error.status === 0) {
             reject({result: RequestResult.CONNECTION_PROBLEM});
@@ -71,4 +71,4 @@ export class AnzeigenProviderService extends DataProviderService {
         });
     }));
   }
-  }
+}

--- a/bogenliga/src/app/modules/wkdurchfuehrung/services/anzeigen-provider.service.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/services/anzeigen-provider.service.ts
@@ -56,4 +56,19 @@ export class AnzeigenProviderService extends DataProviderService {
             });
       }));
     }
+
+  public getNewPhysischeBildschirmID(): Promise<BogenligaResponse<string>> {
+    return new Promise(((resolve, reject) => {
+      this.restClient.GET(this.getUrl())
+        .then((data: string) => {
+          resolve({result: RequestResult.SUCCESS, payload: data});
+        }, (error: HttpErrorResponse) => {
+          if (error.status === 0) {
+            reject({result: RequestResult.CONNECTION_PROBLEM});
+          } else {
+            reject({result: RequestResult.FAILURE});
+          }
+        });
+    }));
+  }
   }

--- a/bogenliga/src/app/modules/wkdurchfuehrung/wkdurchfuehrung.module.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/wkdurchfuehrung.module.ts
@@ -13,6 +13,7 @@ import {
   TabletAdminComponent,
   PfeilNumberOnlyDirective,
   FehlerpunkteNumberOnlyDirective,
+  AnzeigePhysischeIDComponent,
 } from '../wkdurchfuehrung/components';
 
 import {
@@ -51,6 +52,7 @@ import {AnzeigeManagerComponent} from '@wkdurchfuehrung/components/anzeige-manag
     FullscreenComponent,
     TabletAdminPopUpComponent,
     AnzeigeManagerComponent,
+    AnzeigePhysischeIDComponent,
   ],
   providers: [
     WkdurchfuehrungGuard,

--- a/bogenliga/src/app/modules/wkdurchfuehrung/wkdurchfuehrung.routing.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/wkdurchfuehrung.routing.ts
@@ -20,7 +20,7 @@ export const wkdurchfuehrung_ROUTES: Routes = [
   {path: '', pathMatch: 'full', component: TabletAdminComponent, canActivate: [TabletadminGuard]},
   {path: '', pathMatch: 'full', component: TabletAdminPopUpComponent, canActivate: [WkdurchfuehrungGuard]},
   {path: 'anzeige-manager/:selectedWettkampfId', pathMatch: 'full', component: AnzeigeManagerComponent, canActivate: [WkdurchfuehrungGuard]},
-  {path: 'anzeige-physische-id', pathMatch: 'full', component: AnzeigePhysischeIDComponent, canActivate: [WkdurchfuehrungGuard]},
+  {path: 'bildschirm-registrierung', pathMatch: 'full', component: AnzeigePhysischeIDComponent, canActivate: [WkdurchfuehrungGuard]},
   {path: 'fullscreen', pathMatch: 'full', component: FullscreenComponent, canActivate: [WkdurchfuehrungGuard]},
   {path: ':veranstaltungId/:wettkampfId', pathMatch: 'full', component: WkdurchfuehrungComponent, canActivate: [WkdurchfuehrungGuard]},
   {path: 'tabletadmin/:wettkampfId', pathMatch: 'full', component: TabletAdminComponent, canActivate: [WkdurchfuehrungGuard]},

--- a/bogenliga/src/app/modules/wkdurchfuehrung/wkdurchfuehrung.routing.ts
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/wkdurchfuehrung.routing.ts
@@ -8,6 +8,7 @@ import {TabletAdminComponent} from './components/tablet-admin/tablet-admin.compo
 import {WkdurchfuehrungGuard} from './guards/wkdurchfuehrung.guard';
 import {FullscreenComponent} from '@wkdurchfuehrung/components';
 import {AnzeigeManagerComponent} from '@wkdurchfuehrung/components';
+import {AnzeigePhysischeIDComponent} from '@wkdurchfuehrung/components';
 import {TabletAdminPopUpComponent} from './components/tablet-admin/tablet-admin-pop-up/tablet-admin-pop-up.component';
 import {SchusszettelGuard, TabletadminGuard, TableteingabeGuard} from '@wkdurchfuehrung/guards';
 
@@ -19,6 +20,7 @@ export const wkdurchfuehrung_ROUTES: Routes = [
   {path: '', pathMatch: 'full', component: TabletAdminComponent, canActivate: [TabletadminGuard]},
   {path: '', pathMatch: 'full', component: TabletAdminPopUpComponent, canActivate: [WkdurchfuehrungGuard]},
   {path: 'anzeige-manager/:selectedWettkampfId', pathMatch: 'full', component: AnzeigeManagerComponent, canActivate: [WkdurchfuehrungGuard]},
+  {path: 'anzeige-physische-id', pathMatch: 'full', component: AnzeigePhysischeIDComponent, canActivate: [WkdurchfuehrungGuard]},
   {path: 'fullscreen', pathMatch: 'full', component: FullscreenComponent, canActivate: [WkdurchfuehrungGuard]},
   {path: ':veranstaltungId/:wettkampfId', pathMatch: 'full', component: WkdurchfuehrungComponent, canActivate: [WkdurchfuehrungGuard]},
   {path: 'tabletadmin/:wettkampfId', pathMatch: 'full', component: TabletAdminComponent, canActivate: [WkdurchfuehrungGuard]},


### PR DESCRIPTION
durch den direkten link "/wkdurchfuehrung/bildschirm-registrierung" gelangt man nun an einen Fullscreen der beim Aufrufen einen Code bzw. ID anzeigt

Die ID wird relevant bei der Seite "Anzeigen verwalten" wo die generierte ID dann eingeben wird um die Tabellen des jeweiligen Wettkampfes zu übertragen.

Im code findet sich das entsprechende html, scss und typescript als component unter "bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-physische_ID"

in "bogenliga/src/app/modules/wkdurchfuehrung/services/anzeigen-provider.service.ts" wurde ebenfalls eine Methode hinzugefügt namens "getNewPhysischeBildschirmID()" die auch dazubeiträgt , dass die ID ans Frontend bzw. in die Präsentationsschicht kommt

Das nötige Routing wurde hauptsächlich in den Nötigen Dateien von "bogenliga/src/app/modules/wkdurchfuehrung" um die Seite auch über den Link zu erreichen. 

Die Seite ist auch nur über den Link erreichbar. 

Änderungen in "bogenliga/src/app/modules/wkdurchfuehrung/components/anzeige-manager" die zu beginn aus Falschem Verständnis gemacht wurden, sollten wieder rausgelöscht sein
