### PR TITLE
fix: correct url-mapping for hilfe button link to its docu site

### DIFF
--- a/bogenliga/src/app/modules/vereine/components/vereine/vereine.component.html
+++ b/bogenliga/src/app/modules/vereine/components/vereine/vereine.component.html
@@ -1,5 +1,5 @@
 <bla-navigation-dialog [config]="config">
-  <bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:vereine"></bla-hilfe-button>
+  <bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/vereine-ubersicht-aller-vereine"></bla-hilfe-button>
   <p class="subtitle">{{ 'VEREINE.VEREINE.DESCRIPTION' | translate }}</p>
 
   <bla-quicksearch (onSearchEntry)="findBySearch($event)"


### PR DESCRIPTION
added: correct link to current documentation webpage