### PR TITLE
swt2#2102: Hilfe-Links auf neue Dokumentation umstellen

### DIFF
--- a/bogenliga/src/app/modules/ligatabelle/components/ligatabelle/ligatabelle.component.html
+++ b/bogenliga/src/app/modules/ligatabelle/components/ligatabelle/ligatabelle.component.html
@@ -1,6 +1,6 @@
 <bla-common-dialog [config]="config">
   <div (mouseover)="onMouseOver($event)">
-    <bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:ligatabelle"
+    <bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/ligatabelle"
                       target="_blank"></bla-hilfe-button>
     <p class="subtitle">{{'WETTKAEMPFE.LIGATABELLE.DESCRIPTION' | translate}}</p>
     <div class="layout-elements">

--- a/bogenliga/src/app/modules/vereine/components/vereine/vereine.component.html
+++ b/bogenliga/src/app/modules/vereine/components/vereine/vereine.component.html
@@ -1,5 +1,5 @@
 <bla-navigation-dialog [config]="config">
-  <bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:vereine"></bla-hilfe-button>
+  <bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/vereine-ubersicht-aller-vereine"></bla-hilfe-button>
   <p class="subtitle">{{ 'VEREINE.VEREINE.DESCRIPTION' | translate }}</p>
 
   <bla-quicksearch (onSearchEntry)="findBySearch($event)"

--- a/bogenliga/src/app/modules/verwaltung/components/dsb-mitglied/dsb-mitglied-overview/dsb-mitglied-overview.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/dsb-mitglied/dsb-mitglied-overview/dsb-mitglied-overview.component.html
@@ -1,4 +1,4 @@
-<bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/vereinsmitglied-anlegen"
+<bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/vereinsmitglieder-verwalten"
                   target="_blank"></bla-hilfe-button>
 <bla-overview-dialog (onDeleteClicked)="onDelete($event)"
                      (onEditClicked)="onEdit($event)"

--- a/bogenliga/src/app/modules/verwaltung/components/dsb-mitglied/dsb-mitglied-overview/dsb-mitglied-overview.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/dsb-mitglied/dsb-mitglied-overview/dsb-mitglied-overview.component.html
@@ -1,4 +1,4 @@
-<bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:verwaltung_mitglieder-uebersicht"
+<bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/vereinsmitglied-anlegen"
                   target="_blank"></bla-hilfe-button>
 <bla-overview-dialog (onDeleteClicked)="onDelete($event)"
                      (onEditClicked)="onEdit($event)"

--- a/bogenliga/src/app/modules/verwaltung/components/liga/liga-overview/liga-overview.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/liga/liga-overview/liga-overview.component.html
@@ -1,4 +1,4 @@
-<bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:verwaltung_ligen" target="_blank"></bla-hilfe-button>
+<bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/ligen-verwalten" target="_blank"></bla-hilfe-button>
 <bla-overview-dialog [hidden]=false
                      [config]="config"
                      [rows]="rows"

--- a/bogenliga/src/app/modules/verwaltung/components/region/region-overview/region-overview.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/region/region-overview/region-overview.component.html
@@ -1,4 +1,4 @@
-<bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:verwaltung_regionen" target="_blank"></bla-hilfe-button>
+<bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/regionen-verwalten" target="_blank"></bla-hilfe-button>
 <bla-overview-dialog [hidden]=false
                      [config]="config"
                      [rows]="rows"

--- a/bogenliga/src/app/modules/verwaltung/components/user/user-detail/user-detail.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/user/user-detail/user-detail.component.html
@@ -1,4 +1,4 @@
-<bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:benutzerdetails"
+<bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/benutzer-details"
                   target="_blank"></bla-hilfe-button>
 <bla-common-dialog [config]="config"
                    [loading]="loading">

--- a/bogenliga/src/app/modules/verwaltung/components/user/user-neu/user-neu.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/user/user-neu/user-neu.component.html
@@ -1,7 +1,7 @@
 <bla-common-dialog [config]="config"
                    [loading]="loading">
   <div (mouseover)="onMouseOver($event)">
-    <bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:benutzerneuanlage"
+    <bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/neuen-benutzer-anlegen"
                       target="_blank"></bla-hilfe-button>
 
     <a name="bla-selectionlist"></a>

--- a/bogenliga/src/app/modules/verwaltung/components/user/user-overview/user-overview.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/user/user-overview/user-overview.component.html
@@ -1,4 +1,4 @@
-<bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:benutzeruebersicht" target="_blank"></bla-hilfe-button>
+<bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/benutzer-verwalten" target="_blank"></bla-hilfe-button>
 <bla-overview-dialog [hidden]=false
                      [config]="configActive"
                      [rows]="displayRoles"

--- a/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-overview/veranstaltung-overview.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-overview/veranstaltung-overview.component.html
@@ -1,4 +1,4 @@
-<bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:verwaltung_veranstaltungen" target="_blank"></bla-hilfe-button>
+<bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/veranstaltung-verwalten" target="_blank"></bla-hilfe-button>
 <bla-breadcrumbs></bla-breadcrumbs>
 <bla-row-layout>
 

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/mannschaft-detail.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/mannschaft-detail.component.html
@@ -1,7 +1,7 @@
 <bla-common-dialog [config]="config"
                    [loading]="loading">
   <div (mouseover)="onMouseOver($event)">
-    <bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:dsbmannschaftdetails"
+    <bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/vereinsmannschaft-bearbeiten"
                       target="_blank"></bla-hilfe-button>
     <form #mannschaftForm="ngForm"
           class="horizontal-form half-page"

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/schuetzen/schuetzen.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/schuetzen/schuetzen.component.html
@@ -1,7 +1,7 @@
 <bla-common-dialog [config]="config"
                    [loading]="loading">
   <div (mouseover)="onMouseOver($event)">
-    <bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:schuetzemannschafthinzufuegen"
+    <bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/schutze-der-mannschaft-hinzufugen"
                       target="_blank"></bla-hilfe-button>
 
     <form #schützeForm="ngForm"

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.html
@@ -1,7 +1,7 @@
 <bla-common-dialog [config]="config"
                    [loading]="loading">
   <div (mouseover)="onMouseOver($event)">
-    <bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:vereindetails"
+    <bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/verein-details"
                       target="_blank"></bla-hilfe-button>
 
     <form #vereineForm="ngForm"

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-overview/verein-overview.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-overview/verein-overview.component.html
@@ -1,4 +1,4 @@
-<bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:vereine-uebersicht"
+<bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/vereine-verwalten"
                   target="_blank"></bla-hilfe-button>
 
 

--- a/bogenliga/src/app/modules/verwaltung/components/wettkampfklasse/wettkampfklasse-overview/wettkampfklasse-overview.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/wettkampfklasse/wettkampfklasse-overview/wettkampfklasse-overview.component.html
@@ -1,4 +1,4 @@
-<bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:verwaltung_klassen" target="_blank"></bla-hilfe-button>
+<bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/klassenubersicht" target="_blank"></bla-hilfe-button>
 <bla-overview-dialog [hidden]=false
                      [config]="config"
                      [rows]="rows"

--- a/bogenliga/src/app/modules/wettkampf/components/wettkampf/wettkampf.component.html
+++ b/bogenliga/src/app/modules/wettkampf/components/wettkampf/wettkampf.component.html
@@ -1,6 +1,6 @@
 <bla-common-dialog [config]="config">
   <div (mouseover)="onMouseOver($event)">
-    <bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:wettkaempfe"
+    <bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/wettkampfergebnisse"
                       target="_blank"></bla-hilfe-button>
     <p class="subtitle">{{'VEREINE.VEREINE.DESCRIPTION' | translate}}</p>
     <form class="horizontal-form half-page"

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.html
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/wkdurchfuehrung/wkdurchfuehrung.component.html
@@ -1,7 +1,7 @@
 <bla-common-dialog [config]="config">
 
   <div (mouseover)="onMouseOver()">
-    <bla-hilfe-button href="https://wiki.bsapp.de/doku.php?id=liga:wettkampfdurchfuehrung"
+    <bla-hilfe-button href="https://docs.bsapp.de/books/funktionen-der-app/page/wettkampfdurchfuhrung"
                       target="_blank"></bla-hilfe-button>
 
     <p class="subtitle">{{'WKDURCHFUEHRUNG.WKDURCHFUEHRUNG.DESCRIPTION' | translate}}</p>


### PR DESCRIPTION
Die Fragezeichen-Hilfe-Buttons verwiesen auf das alte DokuWiki (wiki.bsapp.de), was je nach Browser zu Fehlermeldungen oder dem Download einer leeren PHP-Datei fuehrte.

Alle Links mit passendem Artikel auf die neue Doku (docs.bsapp.de, Buch 'Funktionen der App') umgestellt - 15 Seiten, alle Ziel-URLs mit HTTP 200 geprueft. Oeffnen im neuen Tab bleibt durch target='_blank' gewaehrleistet.

Ohne passenden Doku-Artikel und daher unveraendert: Migration und DSB-Mitglieder-Uebersicht.