### PR TITLE
fix: Phantom-Fehlermeldung bei "Alle Lizenzen drucken" entfernt (swt2#2173)

### DIFF
--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/mannschaft-detail.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/mannschaft-detail.component.html
@@ -156,13 +156,12 @@
           routerLink="add">
           <span> Neu</span>
         </bla-actionbutton>
-        <bla-download-actionbutton
+        <bla-actionbutton
           (click)="onDownloadLizenzen()"
           [color]="ActionButtonColors.SUCCESS"
           [iconClass]="'file-download'">
           <span> Alle Lizenzen drucken</span>
-          <router-outlet name="onDownloadLizenzen"></router-outlet>
-        </bla-download-actionbutton>
+        </bla-actionbutton>
       </div>
       <bla-data-table (onDeleteEntry)="onDeleteMitglied($event)"
                       (onDownloadEntry)="onDownload($event)"


### PR DESCRIPTION
Ticket: #2173

Der Button "Alle Lizenzen drucken" war eine <bla-download-actionbutton>, die beim Klick zusaetzlich einen eigenen Download auf eine undefinierte URL ausgeloest hat. Dieser schlug fehl und zeigte faelschlich "Download fehlgeschlagen fuer:", obwohl das PDF ueber onDownloadLizenzen() korrekt geladen wurde.

Komponente durch <bla-actionbutton> ersetzt, sodass beim Klick nur noch der echte Download via onDownloadLizenzen() laeuft. Das ungenutzte router-outlet "onDownloadLizenzen" wurde entfernt.