### PR TITLE
fix: falsches Button-Label „Mannschaft anlegen" → „DSB-Mitglied anlegen" (swt2#2171)

### DIFF
--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/ausrichter-user/teilnehmende-mannschaften-button.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/ausrichter-user/teilnehmende-mannschaften-button.cy.js
@@ -1,0 +1,24 @@
+/**
+ * Ticket swt2#2171:
+ * In der Wettkampfdurchfuehrung war der Button im Bereich "Teilnehmende Mannschaften"
+ * faelschlich mit "Mannschaft anlegen" beschriftet, oeffnet aber ueber addDSBMitglied()
+ * den DSB-Mitglied-Dialog. Das Label muss "DSB-Mitglied anlegen" lauten.
+ *
+ * Login als Ausrichter (Rolle aus dem Ticket).
+ * Hinweis: Der Button wird unabhaengig von vorhandenen Eintraegen gerendert,
+ * der Test ist also nicht von Testdaten abhaengig.
+ */
+describe('Ausrichter - Wettkampfdurchfuehrung: korrektes Button-Label', () => {
+
+  it('Button heisst "DSB-Mitglied anlegen" und nicht "Mannschaft anlegen"', () => {
+    cy.loginAusrichter();
+
+    // Direkt zur Wettkampfdurchfuehrung-Detailseite (lokale Testdaten: Veranstaltung 0, Wettkampf 30).
+    cy.visit('http://localhost:4200/#/wkdurchfuehrung/0/30');
+
+    // korrektes Label vorhanden ...
+    cy.contains('button', 'DSB-Mitglied anlegen', { timeout: 20000 }).should('be.visible');
+    // ... und das falsche Label existiert nicht mehr.
+    cy.contains('button', 'Mannschaft anlegen').should('not.exist');
+  });
+});

--- a/bogenliga/src/app/modules/wkdurchfuehrung/components/teilnemende-manschaften-tabelle/teilnemende-manschaften-tabelle.component.html
+++ b/bogenliga/src/app/modules/wkdurchfuehrung/components/teilnemende-manschaften-tabelle/teilnemende-manschaften-tabelle.component.html
@@ -5,7 +5,7 @@
     [id]="'DSB-Mitglied anlegen'"
     [iconClass]="'user-plus'"
     (onClick)="addDSBMitglied()">
-    Mannschaft anlegen
+    DSB-Mitglied anlegen
   </bla-actionbutton>
 <div>
   <bla-data-table


### PR DESCRIPTION
Problem: In der Wettkampfdurchführung (Teilnehmende Mannschaften) war ein Button
mit „Mannschaft anlegen" beschriftet, führte beim Klick aber zu den
DSB-Mitglied-Details.
Ursache: Nur das sichtbare Label war falsch. Die Aktion (addDSBMitglied → öffnet
den DSB-Mitglied-Dialog), das Icon (user-plus) und die id ('DSB-Mitglied anlegen')
gehören alle zu „Mitglied anlegen".
Fix: Label an das tatsächliche Verhalten angepasst → „DSB-Mitglied anlegen".