### PR TITLE
Swt2#2168xcyphrestest merged

### DIFF
--- a/bogenliga/src/app/modules/schusszettel/components/kampfrichter-ansicht/kampfrichter-ansicht.component.html
+++ b/bogenliga/src/app/modules/schusszettel/components/kampfrichter-ansicht/kampfrichter-ansicht.component.html
@@ -5,40 +5,42 @@
   <div *ngIf="errorMsg" class="error-msg">{{ errorMsg }}</div>
 
   <div *ngIf="!loading && !errorMsg">
-    <p *ngIf="matches.length === 0">Keine Matches gefunden.</p>
+    <p *ngIf="matchGroups.length === 0">Keine Matches gefunden.</p>
 
-    <div *ngFor="let match of matches" class="match-card">
-      <div class="match-header">
-        <span class="scheibe">Scheibe {{ match.matchScheibennummer }}</span>
-        <span class="mannschaft">{{ match.mannschaftName }}</span>
-        <span class="begegnung">Begegnung {{ match.begegnung }}</span>
-        <span *ngIf="savedMatchIds.has(match.matchId)" class="saved-hint">&#x2713; gespeichert</span>
+    <div *ngFor="let group of matchGroups" class="match-group">
+
+      <div class="match-group-header" (click)="toggleMatch(group)">
+        <span class="chevron">{{ group.expanded ? '▼' : '▶' }}</span>
+        <span class="match-title">Match {{ group.begegnung }}</span>
+        <span class="scheiben-count">{{ group.scheiben.length }} Scheibe(n)</span>
       </div>
 
-      <div class="strafpunkte-grid">
-        <label>
-          Satz 1
-          <input type="number" min="0" max="99" [(ngModel)]="match.strafPunkteSatz1">
-        </label>
-        <label>
-          Satz 2
-          <input type="number" min="0" max="99" [(ngModel)]="match.strafPunkteSatz2">
-        </label>
-        <label>
-          Satz 3
-          <input type="number" min="0" max="99" [(ngModel)]="match.strafPunkteSatz3">
-        </label>
-        <label>
-          Satz 4
-          <input type="number" min="0" max="99" [(ngModel)]="match.strafPunkteSatz4">
-        </label>
-        <label>
-          Satz 5
-          <input type="number" min="0" max="99" [(ngModel)]="match.strafPunkteSatz5">
-        </label>
+      <div *ngIf="group.expanded" class="scheiben-list">
+
+        <div *ngFor="let match of group.scheiben" class="scheibe-card">
+
+          <div class="scheibe-header" (click)="toggleScheibe(match.matchId)">
+            <span class="chevron">{{ isScheibeExpanded(match.matchId) ? '▼' : '▶' }}</span>
+            <span class="scheibe-label">Scheibe {{ match.matchScheibennummer }}</span>
+            <span class="mannschaft-name">{{ match.mannschaftName }}</span>
+            <span *ngIf="match.sessionStatus" class="session-status">{{ match.sessionStatus }}</span>
+            <span *ngIf="savedMatchIds.has(match.matchId)" class="saved-hint">&#x2713; gespeichert</span>
+          </div>
+
+          <div *ngIf="isScheibeExpanded(match.matchId)" class="strafpunkte-content">
+            <div class="strafpunkte-grid">
+              <label>Satz 1<input type="number" min="0" max="99" [(ngModel)]="match.strafPunkteSatz1"></label>
+              <label>Satz 2<input type="number" min="0" max="99" [(ngModel)]="match.strafPunkteSatz2"></label>
+              <label>Satz 3<input type="number" min="0" max="99" [(ngModel)]="match.strafPunkteSatz3"></label>
+              <label>Satz 4<input type="number" min="0" max="99" [(ngModel)]="match.strafPunkteSatz4"></label>
+              <label>Satz 5<input type="number" min="0" max="99" [(ngModel)]="match.strafPunkteSatz5"></label>
+            </div>
+            <button class="save-btn" (click)="saveStrafpunkte(match)">Speichern</button>
+          </div>
+
+        </div>
       </div>
 
-      <button class="save-btn" (click)="saveStrafpunkte(match)">Speichern</button>
     </div>
   </div>
 </div>

--- a/bogenliga/src/app/modules/schusszettel/components/kampfrichter-ansicht/kampfrichter-ansicht.component.html
+++ b/bogenliga/src/app/modules/schusszettel/components/kampfrichter-ansicht/kampfrichter-ansicht.component.html
@@ -20,7 +20,6 @@
         <span class="chevron">{{ group.expanded ? '▼' : '▶' }}</span>
         <span class="match-title">Match {{ group.begegnung }}</span>
         <span class="scheiben-count">{{ group.scheiben.length }} Scheibe(n)</span>
-        <span *ngIf="groupHasMeldungFehlt(group)" class="group-status fehlt">⚠ Meldung fehlt</span>
       </div>
 
       <div *ngIf="group.expanded" class="scheiben-list">

--- a/bogenliga/src/app/modules/schusszettel/components/kampfrichter-ansicht/kampfrichter-ansicht.component.scss
+++ b/bogenliga/src/app/modules/schusszettel/components/kampfrichter-ansicht/kampfrichter-ansicht.component.scss
@@ -43,7 +43,7 @@
 // ── Level 1: Match / Begegnung ─────────────────────────────────────────────
 
 .match-group {
-  border: 1px solid #ccc;
+  border: 1px solid #EAEAEF;
   border-radius: 8px;
   margin-bottom: 0.75rem;
   overflow: hidden;
@@ -55,42 +55,33 @@
   align-items: center;
   gap: 0.75rem;
   padding: 0.85rem 1rem;
-  background: #1a1a2e;
-  color: #fff;
-  font-weight: bold;
+  background: #EAEAEF;
+  color: #2A2A2A;
+  font-weight: 600;
   cursor: pointer;
   user-select: none;
+  border-left: 4px solid #487AF5;
 
   &:hover {
-    background: #16213e;
+    background: #d8d8e0;
   }
 
   .chevron {
     font-size: 0.75rem;
     min-width: 1rem;
+    color: #487AF5;
   }
 
   .match-title {
     flex: 1;
     font-size: 1rem;
+    color: #2A2A2A;
   }
 
   .scheiben-count {
     font-size: 0.8rem;
     font-weight: normal;
-    opacity: 0.75;
-  }
-
-  .group-status {
-    font-size: 0.78rem;
-    font-weight: 600;
-    padding: 2px 8px;
-    border-radius: 10px;
-
-    &.fehlt {
-      background: rgba(231,76,60,0.25);
-      color: #ff8a80;
-    }
+    color: #888888;
   }
 }
 
@@ -137,7 +128,7 @@
   }
 
   .scheibe-badge {
-    background: #1a1a2e;
+    background: #487AF5;
     color: #fff;
     border-radius: 4px;
     padding: 2px 8px;

--- a/bogenliga/src/app/modules/schusszettel/components/kampfrichter-ansicht/kampfrichter-ansicht.component.scss
+++ b/bogenliga/src/app/modules/schusszettel/components/kampfrichter-ansicht/kampfrichter-ansicht.component.scss
@@ -13,24 +13,109 @@
   font-weight: bold;
 }
 
-.match-card {
-  border: 1px solid #ddd;
+// ── Level 1: Match-Gruppe ──────────────────────────────────────────────────
+
+.match-group {
+  border: 1px solid #ccc;
   border-radius: 6px;
-  padding: 1rem;
-  margin-bottom: 1rem;
-  background: #fafafa;
-}
-
-.match-header {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
   margin-bottom: 0.75rem;
-  font-weight: bold;
+  overflow: hidden;
 }
 
-.saved-hint {
-  color: #27ae60;
+.match-group-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  background: #2980b9;
+  color: white;
+  font-weight: bold;
+  font-size: 1rem;
+  cursor: pointer;
+  user-select: none;
+
+  &:hover {
+    background: #2471a3;
+  }
+
+  .chevron {
+    font-size: 0.75rem;
+    min-width: 1rem;
+  }
+
+  .match-title {
+    flex: 1;
+  }
+
+  .scheiben-count {
+    font-size: 0.8rem;
+    font-weight: normal;
+    opacity: 0.85;
+  }
+}
+
+// ── Level 2: Scheibe innerhalb eines Matches ───────────────────────────────
+
+.scheiben-list {
+  background: #f9f9f9;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.scheibe-card {
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background: #fff;
+  overflow: hidden;
+}
+
+.scheibe-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 1rem;
+  cursor: pointer;
+  user-select: none;
+  font-weight: 500;
+
+  &:hover {
+    background: #eaf2fb;
+  }
+
+  .chevron {
+    font-size: 0.7rem;
+    min-width: 1rem;
+    color: #555;
+  }
+
+  .scheibe-label {
+    color: #555;
+    font-size: 0.9rem;
+  }
+
+  .mannschaft-name {
+    flex: 1;
+  }
+
+  .session-status {
+    font-size: 0.78rem;
+    color: #7f8c8d;
+    font-style: italic;
+  }
+
+  .saved-hint {
+    color: #27ae60;
+    font-weight: bold;
+  }
+}
+
+// ── Strafpunkte-Inhalt ──────────────────────────────────────────────────────
+
+.strafpunkte-content {
+  padding: 0.75rem 1rem 1rem;
+  border-top: 1px solid #eee;
 }
 
 .strafpunkte-grid {

--- a/bogenliga/src/app/modules/schusszettel/components/kampfrichter-ansicht/kampfrichter-ansicht.component.ts
+++ b/bogenliga/src/app/modules/schusszettel/components/kampfrichter-ansicht/kampfrichter-ansicht.component.ts
@@ -123,7 +123,7 @@ export class KampfrichterAnsichtComponent implements OnInit, OnDestroy {
       .sort((a, b) => a[0] - b[0])
       .map(([begegnung, scheiben]) => ({
         begegnung,
-        scheiben: scheiben.sort((a, b) => a.matchScheibennummer - b.matchScheibennummer),
+        scheiben: scheiben.sort((a, b) => a.nr !== b.nr ? a.nr - b.nr : a.matchScheibennummer - b.matchScheibennummer),
         expanded: this.matchGroups.find(g => g.begegnung === begegnung)?.expanded ?? false
       }));
   }

--- a/bogenliga/src/app/modules/schusszettel/components/kampfrichter-ansicht/kampfrichter-ansicht.component.ts
+++ b/bogenliga/src/app/modules/schusszettel/components/kampfrichter-ansicht/kampfrichter-ansicht.component.ts
@@ -4,6 +4,12 @@ import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {KampfrichterAnsichtService, KampfrichterMatchDO} from '@schusszettel/services/kampfrichter-ansicht.service';
 
+export interface MatchGroup {
+  begegnung: number;
+  scheiben: KampfrichterMatchDO[];
+  expanded: boolean;
+}
+
 @Component({
   selector: 'bla-kampfrichter-ansicht',
   templateUrl: './kampfrichter-ansicht.component.html',
@@ -13,7 +19,8 @@ export class KampfrichterAnsichtComponent implements OnInit, OnDestroy {
 
   wettkampfId!: number;
   token!: string;
-  matches: KampfrichterMatchDO[] = [];
+  matchGroups: MatchGroup[] = [];
+  expandedScheiben = new Set<number>();
   loading = false;
   errorMsg: string | null = null;
   savedMatchIds = new Set<number>();
@@ -46,16 +53,47 @@ export class KampfrichterAnsichtComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (data) => {
-          this.matches = data;
+          this.matchGroups = this.buildGroups(data);
           this.loading = false;
         },
         error: (err) => {
-          this.errorMsg = err.status === 403
-            ? 'Ungültiger Zugangstoken.'
-            : 'Fehler beim Laden der Matches.';
+          if (err.status === 401 || err.status === 403) {
+            this.errorMsg = 'Kein Zugriff. Bitte öffne den Link über den QR-Code des Wettkampfes.';
+          } else {
+            this.errorMsg = 'Fehler beim Laden der Matches.';
+          }
           this.loading = false;
         }
       });
+  }
+
+  private buildGroups(matches: KampfrichterMatchDO[]): MatchGroup[] {
+    const map = new Map<number, KampfrichterMatchDO[]>();
+    for (const m of matches) {
+      if (!map.has(m.begegnung)) {
+        map.set(m.begegnung, []);
+      }
+      map.get(m.begegnung)!.push(m);
+    }
+    return Array.from(map.entries())
+      .sort((a, b) => a[0] - b[0])
+      .map(([begegnung, scheiben]) => ({begegnung, scheiben, expanded: false}));
+  }
+
+  toggleMatch(group: MatchGroup): void {
+    group.expanded = !group.expanded;
+  }
+
+  toggleScheibe(matchId: number): void {
+    if (this.expandedScheiben.has(matchId)) {
+      this.expandedScheiben.delete(matchId);
+    } else {
+      this.expandedScheiben.add(matchId);
+    }
+  }
+
+  isScheibeExpanded(matchId: number): boolean {
+    return this.expandedScheiben.has(matchId);
   }
 
   saveStrafpunkte(match: KampfrichterMatchDO): void {

--- a/bogenliga/src/app/modules/schusszettel/services/kampfrichter-ansicht.service.ts
+++ b/bogenliga/src/app/modules/schusszettel/services/kampfrichter-ansicht.service.ts
@@ -15,6 +15,7 @@ export interface KampfrichterMatchDO {
   strafPunkteSatz3: number;
   strafPunkteSatz4: number;
   strafPunkteSatz5: number;
+  sessionStatus?: string;
 }
 
 @Injectable({providedIn: 'root'})

--- a/bogenliga/src/app/modules/shared/data-provider/interceptors/error-interceptor.class.ts
+++ b/bogenliga/src/app/modules/shared/data-provider/interceptors/error-interceptor.class.ts
@@ -42,6 +42,9 @@ export class ErrorInterceptor implements HttpInterceptor {
                      //TODO Locally the backend returns 0 as status code and on the DEV-Environment it returns 401
                      //TODO More research is needed to why the server return different status codes
                      if (error.status === 0 || error.status === 401) {
+                       if (request.url.includes('kampfrichter-session')) {
+                         throw error;
+                       }
                        console.log('Exipred Token', error);
                        if (isNullOrUndefined(error.error)) {
                          error.error = {};


### PR DESCRIPTION
- Match-Gruppierung: Kacheln werden nicht mehr flach nach Scheibe, sondern nach Begegnung (Match) gruppiert. Jede Begegnung ist einzeln aufklappbar, darin sind die einzelnen Scheiben ebenfalls aufklappbar.
- Sortierung: Innerhalb einer Begegnung sind die Scheiben nach Match-Nr sortiert, sodass zwei gegeneinander spielende Vereine immer direkt untereinander erscheinen.
- Stil: Match-Gruppen-Header verwenden jetzt das Farbschema der Website (#EAEAEF, #487AF5) statt des bisherigen dunklen Hintergrunds.
- "Meldung fehlt"-Badge: Wird nur noch bei der einzelnen Scheibe/Verein angezeigt, nicht mehr als Zusammenfassung auf der Match-Gruppe.
- 401-Fix: Der globale Error-Interceptor überschreibt 401-Antworten von /v1/kampfrichter-session nicht mehr mit "Sitzung abgelaufen", sondern gibt eine passende Fehlermeldung aus.