### PR TITLE
fix: verständliche i18n-Meldung für volle Veranstaltung (swt2#2186)

### DIFF
--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/ligaleiter-user/vereinsmannschaft-nummer-validierung.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/ligaleiter-user/vereinsmannschaft-nummer-validierung.cy.js
@@ -1,0 +1,35 @@
+/**
+ * Ticket swt2#2174:
+ * Beim Anlegen einer Vereinsmannschaft fuehrte eine nicht-numerische
+ * Mannschaftsnummer (z.B. "ab") zu einer generischen "Vom Server abgewiesen"-
+ * Fehlermeldung, weil das Feld nur 'required', aber nicht numerisch validiert war.
+ *
+ * Nach dem Fix (pattern="[0-9]+") wird eine ungueltige Eingabe bereits im
+ * Frontend abgefangen: Das Feld wird als ungueltig markiert und der
+ * Speichern-Button bleibt gesperrt -> kein Server-Call, keine kryptische Meldung.
+ *
+ * Login als Ligaleiter (Rolle aus dem Ticket).
+ */
+describe('Ligaleiter - Vereinsmannschaft anlegen: Mannschaftsnummer-Validierung', () => {
+
+  before(() => {
+    cy.visit('http://localhost:4200/#/user/login');
+    cy.get('#loginEmail').type('HSRT-Test@bogenliga.de');
+    cy.get('#loginPassword').type('mki4HSRT');
+    cy.get('#loginButton').click();
+    cy.url({ timeout: 20000 }).should('include', '/home');
+  });
+
+  it('lehnt eine nicht-numerische Mannschaftsnummer ab (Feld ungueltig, Speichern gesperrt)', () => {
+    // Anlege-Formular einer Vereinsmannschaft (lokale Testdaten: Verein 11).
+    cy.visit('http://localhost:4200/#/verwaltung/vereine/11/add');
+
+    // nicht-numerische Eingabe
+    cy.get('[data-cy=vereine-mannschaft-detail-mannschaftsnummer]', { timeout: 20000 }).type('ab');
+
+    // Feld wird als ungueltig markiert ...
+    cy.get('[data-cy=vereine-mannschaft-detail-mannschaftsnummer]').should('have.class', 'is-invalid');
+    // ... und der Speichern-Button bleibt gesperrt (kein Server-Call, keine generische Fehlermeldung).
+    cy.get('[data-cy=vereine-mannschaft-detail-save-button] button').should('be.disabled');
+  });
+});

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/mannschaft-detail.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/mannschafts-detail/mannschaft-detail.component.html
@@ -44,6 +44,7 @@
                  id="mannschaftNummer"
                  maxlength="2"
                  name="mannschaftNummer"
+                 pattern="[0-9]+"
                  placeholder="{{ 'MANAGEMENT.MANNSCHAFT_DETAIL.FORM.MANNSCHAFT_NUMMER.PLACEHOLDER' | translate }}"
                  required
                  type="text">

--- a/bogenliga/src/assets/i18n/de.json
+++ b/bogenliga/src/assets/i18n/de.json
@@ -1909,6 +1909,10 @@
         "TITLE": "Ungültige Anfrage",
         "DESCRIPTION": "Ihre Anfrage wurde vom Server abgewiesen."
       },
+      "VERANSTALTUNG_MAX_CAPACITY_ERROR": {
+        "TITLE": "Veranstaltung ausgebucht",
+        "DESCRIPTION": "Die Veranstaltung hat ihre maximale Kapazität erreicht. Es kann keine weitere Mannschaft hinzugefügt werden."
+      },
       "INVALID_SIGN_IN_CREDENTIALS": {
         "TITLE": "Anmeldung nicht erfolgreich",
         "DESCRIPTION": "Bitte prüfen sie E-Mail-Adresse und Passwort"


### PR DESCRIPTION
Ergänzt NOTIFICATION.ERROR.VERANSTALTUNG_MAX_CAPACITY_ERROR (de.json), passend
zum neuen Backend-Fehlercode. Statt des rohen Backend-Strings erscheint nun
"Veranstaltung ausgebucht" mit verständlicher Beschreibung.