### PR TITLE
fix: Vereine-Liste bei leerer Suche auf Bezirks-Liste zurücksetzen (swt2#2160)

### DIFF
--- a/bogenliga/src/app/modules/vereine/components/vereine/vereine.component.spec.ts
+++ b/bogenliga/src/app/modules/vereine/components/vereine/vereine.component.spec.ts
@@ -1,0 +1,45 @@
+import {VereineComponent} from './vereine.component';
+import {VereinDataProviderService} from '@verwaltung/services/verein-data-provider.service';
+
+/**
+ * Ticket swt2#2160:
+ * Beim Leeren der Suche blieb die Vereine-Liste auf dem Suchergebnis (alle Vereine)
+ * stehen, statt zur initialen (Bezirks-)Liste zurueckzukehren.
+ *
+ * findBySearch('') muss jetzt loadVereine() (findAll) aufrufen, nicht findBySearch.
+ */
+describe('VereineComponent - findBySearch (swt2#2160)', () => {
+
+  let component: VereineComponent;
+  let vereinDataProvider: jasmine.SpyObj<VereinDataProviderService>;
+
+  beforeEach(() => {
+    vereinDataProvider = jasmine.createSpyObj('VereinDataProviderService', ['findAll', 'findBySearch']);
+    vereinDataProvider.findAll.and.returnValue(Promise.resolve({payload: []} as any));
+    vereinDataProvider.findBySearch.and.returnValue(Promise.resolve({payload: []} as any));
+
+    // Router/ActivatedRoute werden in findBySearch nicht benoetigt -> Stubs reichen.
+    component = new VereineComponent({} as any, {} as any, vereinDataProvider);
+  });
+
+  it('laedt bei leerer Suche die initiale (Bezirks-)Liste via findAll, nicht via findBySearch', () => {
+    component.findBySearch('');
+
+    expect(vereinDataProvider.findAll).toHaveBeenCalled();
+    expect(vereinDataProvider.findBySearch).not.toHaveBeenCalled();
+  });
+
+  it('laedt bei reiner Leerzeichen-Eingabe ebenfalls die initiale Liste via findAll', () => {
+    component.findBySearch('   ');
+
+    expect(vereinDataProvider.findAll).toHaveBeenCalled();
+    expect(vereinDataProvider.findBySearch).not.toHaveBeenCalled();
+  });
+
+  it('sucht bei nicht-leerer Eingabe via findBySearch', () => {
+    component.findBySearch('Ulm');
+
+    expect(vereinDataProvider.findBySearch).toHaveBeenCalledWith('Ulm');
+    expect(vereinDataProvider.findAll).not.toHaveBeenCalled();
+  });
+});

--- a/bogenliga/src/app/modules/vereine/components/vereine/vereine.component.ts
+++ b/bogenliga/src/app/modules/vereine/components/vereine/vereine.component.ts
@@ -33,6 +33,11 @@ export class VereineComponent extends CommonComponentDirective implements OnInit
   }
 
   public findBySearch($event: string) {
+    // Bei leerer Suche zurueck zur initialen (Bezirks-)Liste, statt alle Vereine zu laden (swt2#2160).
+    if (!$event || $event.trim().length === 0) {
+      this.loadVereine();
+      return;
+    }
     this.vereinDataProvider.findBySearch($event)
       .then((response: BogenligaResponse<VereinDTO[]>) => this.handleLoadTableRowsSuccess(response))
       .catch((response: BogenligaResponse<VereinDTO[]>) => this.handleLoadTableRowsFailure());


### PR DESCRIPTION
Problem: Nach einer Suche in "Vereine verwalten" blieb die Liste auf allen
Vereinen stehen – auch nach Leeren der Suche oder Seitenwechsel (Suchwert wird
im localStorage gehalten und erneut angewandt).

Ursache: findBySearch('') lud alle Vereine statt der initialen Bezirks-Liste.

Fix: Bei leerer Suche wird loadVereine() (findAll = Bezirks-Liste) aufgerufen.
Unit-Test ergänzt (leere Suche → findAll; nicht-leere → findBySearch).