### PR TITLE
swt2#2103: Liga-Kontext bleibt bei Navigation zu Verein und Feedback-…

### DIFF
--- a/bogenliga/cypress/e2e/bsapp/wettkampstatistiken-und-tabellenansichten/liga-kontext-erhalt.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/wettkampstatistiken-und-tabellenansichten/liga-kontext-erhalt.cy.js
@@ -1,0 +1,67 @@
+/**
+ * BSAPP-2103 — "Auswahl Liga wird zurückgesetzt"
+ *
+ * Wenn man aus den Wettkampfergebnissen zu einem Verein/einer Mannschaft navigiert,
+ * darf der Liga-Kontext nicht verloren gehen. Die Sidebar-Einträge "Wettkampfergebnisse"
+ * (sidebar-wettkampf-button) und "Ligatabelle" (sidebar-ligatabelle-button) werden nur
+ * angezeigt, solange ein Liga-Kontext aktiv ist (requiresLigaContext). Gleiches gilt für
+ * den Feedback-Klick im Footer, der vorher den ?liga=-QueryParam verworfen hat.
+ *
+ * Testdaten (LOCAL-DB): Liga-ID 2 ("Württembergliga Recurve"), Veranstaltung 0,
+ * Mannschaft 101 / Verein 0. Der LigaResolver akzeptiert numerische Liga-IDs (findById).
+ */
+
+const LIGA_ID = 2;
+const VEREIN_ID = 0;
+const MANNSCHAFT_ID = 101;
+
+describe('BSAPP-2103: Liga-Kontext bleibt bei Navigation erhalten', () => {
+
+  beforeEach(() => {
+    cy.loginAdmin();
+    cy.url({timeout: 20000}).should('include', '/home');
+  });
+
+  it('positiv: Liga-Kontext (Sidebar-Einträge) bleibt nach Navigation zu einem Verein erhalten', () => {
+    // Liga-Kontext aufbauen, indem die Wettkampfergebnisse mit liga-Param geöffnet werden.
+    cy.visit(`http://localhost:4200/#/wettkaempfe?liga=${LIGA_ID}`);
+
+    // Vorbedingung: mit aktivem Liga-Kontext sind beide Einträge vorhanden.
+    cy.get('[data-cy=sidebar-wettkampf-button]', {timeout: 20000}).should('exist');
+    cy.get('[data-cy=sidebar-ligatabelle-button]').should('exist');
+
+    // Navigation zu einem Verein/einer Mannschaft OHNE liga-Param – genau so verlinken
+    // die Wettkampfergebnisse (['/vereine', vereinId, mannschaftId]).
+    cy.visit(`http://localhost:4200/#/vereine/${VEREIN_ID}/${MANNSCHAFT_ID}`);
+
+    // POSITIV: Der LigaStickyGuard hängt den gemerkten liga-Param wieder an,
+    // sodass der Kontext (und damit die Sidebar-Einträge) erhalten bleibt.
+    cy.url({timeout: 20000}).should('include', 'liga=');
+    cy.get('[data-cy=sidebar-wettkampf-button]').should('exist');
+    cy.get('[data-cy=sidebar-ligatabelle-button]').should('exist');
+  });
+
+  it('negativ: ohne Liga-Kontext erscheinen die liga-abhängigen Sidebar-Einträge nicht', () => {
+    // Home ohne liga-Param leert den Liga-Kontext bewusst (echte Startseite).
+    cy.visit('http://localhost:4200/#/home');
+
+    // NEGATIV: ohne aktiven Liga-Kontext sind die Einträge nicht im DOM –
+    // beweist, dass die Einträge tatsächlich liga-gated sind (Positivtest ist aussagekräftig).
+    cy.get('[data-cy=sidebar-home-button]', {timeout: 20000}).should('exist');
+    cy.get('[data-cy=sidebar-wettkampf-button]').should('not.exist');
+    cy.get('[data-cy=sidebar-ligatabelle-button]').should('not.exist');
+  });
+
+  it('positiv: Klick auf "Feedback" im Footer verwirft den Liga-Kontext nicht', () => {
+    cy.visit(`http://localhost:4200/#/wettkaempfe?liga=${LIGA_ID}`);
+    cy.get('[data-cy=sidebar-wettkampf-button]', {timeout: 20000}).should('exist');
+
+    // Feedback öffnen – darf NICHT auf "#" navigieren und damit den liga-Param verwerfen.
+    cy.get('[data-cy=footer-feedback-link]').click();
+
+    // POSITIV: Popup ist offen, URL behält den liga-Param, Sidebar-Einträge bleiben.
+    cy.url().should('include', `liga=${LIGA_ID}`);
+    cy.get('[data-cy=sidebar-wettkampf-button]').should('exist');
+    cy.get('[data-cy=sidebar-ligatabelle-button]').should('exist');
+  });
+});

--- a/bogenliga/cypress/e2e/bsapp/wettkampstatistiken-und-tabellenansichten/liga-kontext-erhalt.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/wettkampstatistiken-und-tabellenansichten/liga-kontext-erhalt.cy.js
@@ -41,6 +41,21 @@ describe('BSAPP-2103: Liga-Kontext bleibt bei Navigation erhalten', () => {
     cy.get('[data-cy=sidebar-ligatabelle-button]').should('exist');
   });
 
+  it('positiv: Liga-Kontext bleibt auch auf der reinen Verein-Route (/vereine/:id) erhalten', () => {
+    // Antwort auf Review-Frage: Die Route ':id' (VereinComponent) hat KEINEN LigaResolver und
+    // damit auch keinen Guard. Sie kann den Kontext gar nicht leeren; die Sidebar-Einträge
+    // bleiben über den gemerkten Kontext (remembered) erhalten – ohne dass ein Guard nötig ist.
+    cy.visit(`http://localhost:4200/#/wettkaempfe?liga=${LIGA_ID}`);
+    cy.get('[data-cy=sidebar-wettkampf-button]', {timeout: 20000}).should('exist');
+
+    // Reine Verein-Route OHNE mannschaftId und OHNE liga-Param.
+    cy.visit(`http://localhost:4200/#/vereine/${VEREIN_ID}`);
+
+    // POSITIV: Sidebar-Einträge bleiben erhalten (Kontext nicht verloren).
+    cy.get('[data-cy=sidebar-wettkampf-button]', {timeout: 20000}).should('exist');
+    cy.get('[data-cy=sidebar-ligatabelle-button]').should('exist');
+  });
+
   it('negativ: ohne Liga-Kontext erscheinen die liga-abhängigen Sidebar-Einträge nicht', () => {
     // Home ohne liga-Param leert den Liga-Kontext bewusst (echte Startseite).
     cy.visit('http://localhost:4200/#/home');

--- a/bogenliga/src/app/app.component.html
+++ b/bogenliga/src/app/app.component.html
@@ -47,7 +47,9 @@
 
           <!-- Feedback -->
           <li>
-          <a href="#" (click)="popup=true"> {{ 'APP.FEEDBACK' | translate }}
+          <!-- preventDefault verhindert die Navigation auf "#", die sonst den liga-QueryParam
+               (und damit den Liga-Kontext) verwerfen würde (BSAPP-2103). -->
+          <a href="#" (click)="$event.preventDefault(); popup=true" style="cursor: pointer" data-cy="footer-feedback-link"> {{ 'APP.FEEDBACK' | translate }}
           </a>
           </li>
 

--- a/bogenliga/src/app/modules/vereine/vereine.routing.ts
+++ b/bogenliga/src/app/modules/vereine/vereine.routing.ts
@@ -1,10 +1,14 @@
 import {Routes} from '@angular/router';
 import {MannschaftComponent, VereinComponent, VereineComponent} from './components';
 import {LigaResolver} from "@shared/routing/resolvers/liga.resolver";
+import {LigaStickyGuard} from "@shared/routing/guards/liga-sticky.guard";
 
 
 export const VEREINE_ROUTES: Routes = [
   {path: '', pathMatch: 'full', component: VereineComponent},
-  {path: ':id/:mannschaftId', component: MannschaftComponent,resolve: {liga: LigaResolver}},
+  // LigaStickyGuard hängt den gemerkten liga-QueryParam wieder an, bevor der LigaResolver läuft.
+  // Sonst würde der Resolver den Liga-Kontext leeren, wenn man z.B. aus den Wettkampfergebnissen
+  // zu einem Verein/einer Mannschaft navigiert (BSAPP-2103).
+  {path: ':id/:mannschaftId', component: MannschaftComponent, canActivate: [LigaStickyGuard], resolve: {liga: LigaResolver}},
   {path: ':id', pathMatch: 'full', component: VereinComponent},
 ];


### PR DESCRIPTION
…Klick erhalten

Beim Navigieren aus den Wettkampfergebnissen zu einem Verein/einer Mannschaft sowie beim Klick auf den Feedback-Link im Footer ging die Liga-Auswahl verloren, wodurch die Sidebar-Eintraege Wettkampfergebnisse und Ligatabelle verschwanden.

Ursache: Der LigaResolver leert den gemerkten Liga-Kontext, sobald eine Route ohne ?liga=-QueryParam aufgerufen wird. Fix 1: Der bereits vorhandene, aber nirgends eingebundene LigaStickyGuard wird nun als canActivate auf der Verein-/Mannschaft-Route gesetzt und haengt den gemerkten liga-Param wieder an. Fix 2: Der Feedback-Link ruft preventDefault auf, damit die Navigation auf '#' den liga-Param nicht mehr verwirft.

Cypress-Test mit positiver und negativer Assertion ergaenzt (liga-kontext-erhalt.cy.js).