### PR TITLE
swt2#2191: Liga-Suche wendet Permission-Filter an (kein Umgehen mehr)

### DIFF
--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/ligaleiter-user/liga-suche-permission.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/ligaleiter-user/liga-suche-permission.cy.js
@@ -1,0 +1,82 @@
+/**
+ * BSAPP-2191 — Ligaübersicht: Suchfeld darf Permissions nicht umgehen
+ *
+ * In der Ligen-Verwaltung (Verwaltung -> Ligen, /#/verwaltung/liga) sieht ein Ligaleiter
+ * normalerweise nur die Ligen, für die er verantwortlich ist (Nicht-Admin-Filter über
+ * ligaVerantwortlichMail). Über das Suchfeld wurden jedoch ALLE Ligen angezeigt, weil
+ * findBySearch() den Permission-Filter nicht anwendete.
+ *
+ * Fix: Übersicht UND Suche laufen durch dieselbe Filter-Logik (renderLigenForCurrentUser).
+ *
+ * Testdaten (LOCAL-DB): Alle Ligen haben liga_verantwortlich = admin@bogenliga.de,
+ * d.h. der Test-Ligaleiter (TeamLigaleiter@bogenliga.de) ist für KEINE Liga verantwortlich.
+ * Die fremde Liga "Bundesliga" darf für ihn also auch bei Suche nicht erscheinen.
+ */
+
+const SEARCH_TERM = 'Bundesliga';
+const LIGA_OVERVIEW_URL = 'http://localhost:4200/#/verwaltung/liga';
+
+/**
+ * Öffnet die Liga-Übersicht robust: nach dem Login kann der Auth-Guard bei zu frühem
+ * Navigieren noch auf /home umleiten (Permission-Load-Timing) -> einmalig erneut aufrufen.
+ * Wartet anschließend, bis die initiale Übersicht geladen ist.
+ */
+function openLigaOverview() {
+  cy.visit(LIGA_OVERVIEW_URL);
+  cy.wait(1000);
+  cy.location('hash').then((hash) => {
+    if (hash.indexOf('/verwaltung/liga') === -1) {
+      cy.visit(LIGA_OVERVIEW_URL);
+      cy.wait(1000);
+    }
+  });
+  cy.get('bla-overview-dialog', {timeout: 20000}).should('exist').and('not.contain', 'werden geladen');
+}
+
+describe('BSAPP-2191: Liga-Suche umgeht Permissions nicht', () => {
+
+  it('Kontrolle (positiv): Admin sieht bei Suche die Liga "Bundesliga"', () => {
+    // Admin-Login (Shortcut). Kein Cookie-/Storage-Reset -> das würde den Admin-Shortcut-Login stören.
+    cy.loginAdmin();
+    cy.url({timeout: 20000}).should('include', '/home');
+    cy.wait(1500); // Permissions/JWT laden lassen, bevor auf die guard-geschützte Route navigiert wird
+    // Nur den gespeicherten Suchbegriff entfernen, damit die Übersicht sauber lädt (Auth bleibt erhalten).
+    cy.window().then((w) => w.localStorage.removeItem('searchTermLiga'));
+
+    openLigaOverview();
+
+    cy.get('.quicksearch-input', {timeout: 20000}).type(SEARCH_TERM).should('have.value', SEARCH_TERM);
+
+    // Positiv: Der Admin darf alles sehen -> die fremde Liga taucht in der Ergebnisliste auf.
+    // Beweist zugleich, dass der Suchbegriff trifft und der Bypass tatsächlich relevant wäre.
+    cy.get('bla-overview-dialog', {timeout: 20000}).contains('td', SEARCH_TERM).should('exist');
+  });
+
+  it('negativ: Ligaleiter sieht die fremde Liga auch bei Suche NICHT', () => {
+    // Such-Requests mitschneiden, um zu belegen, dass die Suche wirklich ausgeführt wird
+    // (sonst könnte der Test trivial gruen sein).
+    cy.intercept('GET', '**/v1/liga/search/**').as('ligaSearch');
+
+    // Ligaleiter-Login (robuster Inline-Login), frischer State.
+    cy.clearCookies();
+    cy.clearLocalStorage();
+    cy.visit('http://localhost:4200/#/user/login');
+    cy.get('#loginEmail').type('TeamLigaleiter@bogenliga.de');
+    cy.get('#loginPassword').type('swt2');
+    cy.get('#loginButton').click();
+    cy.url({timeout: 20000}).should('include', '/home');
+    cy.wait(1500);
+
+    openLigaOverview();
+
+    cy.get('.quicksearch-input', {timeout: 20000}).type(SEARCH_TERM).should('have.value', SEARCH_TERM);
+
+    // Die Suche wurde tatsächlich an das Backend geschickt ...
+    cy.wait('@ligaSearch', {timeout: 20000});
+    cy.wait(1500); // Rendering der (gefilterten) Ergebnisse abwarten
+    cy.get('bla-overview-dialog').should('not.contain', 'werden geladen');
+
+    // Negativ: Trotz passendem Suchbegriff darf die fremde Liga nicht erscheinen.
+    cy.get('bla-overview-dialog').contains('td', SEARCH_TERM).should('not.exist');
+  });
+});

--- a/bogenliga/src/app/modules/verwaltung/components/liga/liga-overview/liga-overview.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/liga/liga-overview/liga-overview.component.ts
@@ -112,39 +112,38 @@ export class LigaOverviewComponent extends CommonComponentDirective implements O
 
   private loadTableRows() {
     this.ligaDataProvider.findAll()
-        .then((response: BogenligaResponse<LigaDTO[]>) => {
-          this.userDataProviderService.findUserRoleById(this.currentUserService.getCurrentUserID()).then((roleresponse: BogenligaResponse<UserRolleDO[]>) => {
-            if (roleresponse.payload.filter(role => role.roleName == 'ADMIN').length > 0) {
-              this.handleLoadTableRowsSuccess(response);
-            } else {
-              let filtered = response.payload.filter(ligadto => {
-                if (ligadto.ligaVerantwortlichMail === this.currentUserService.getEmail()){
-                  return true;}
-                else {
-                  return false;
-                }
-              })
-              this.handleLoadTableRows(filtered);
-            }
-          });
-        })
+        .then((response: BogenligaResponse<LigaDTO[]>) => this.renderLigenForCurrentUser(response.payload))
         .catch((response: BogenligaResponse<LigaDTO[]>) => this.handleLoadTableRowsFailure(response));
   }
 
   public findBySearch($event: string) {
     this.ligaDataProvider.findBySearch($event)
-        .then((response: BogenligaResponse<LigaDTO[]>) => this.handleLoadTableRowsSuccess(response))
+        .then((response: BogenligaResponse<LigaDTO[]>) => this.renderLigenForCurrentUser(response.payload))
         .catch((response: BogenligaResponse<LigaDTO[]>) => this.handleLoadTableRowsFailure(response));
+  }
+
+  /**
+   * Rendert die Ligen und wendet dabei die Sichtbarkeits-Beschränkung an:
+   * Nicht-Admins (z.B. Ligaleiter) sehen ausschließlich die Ligen, für die sie verantwortlich sind.
+   * Diese Beschränkung greift für die normale Übersicht UND für die Suche, damit das Suchfeld
+   * die Berechtigungen nicht umgehen kann (BSAPP-2191).
+   */
+  private renderLigenForCurrentUser(ligen: LigaDTO[]): void {
+    this.userDataProviderService.findUserRoleById(this.currentUserService.getCurrentUserID())
+        .then((roleresponse: BogenligaResponse<UserRolleDO[]>) => {
+          const isAdmin = roleresponse.payload.filter(role => role.roleName == 'ADMIN').length > 0;
+          if (isAdmin) {
+            this.handleLoadTableRows(ligen);
+          } else {
+            const filtered = ligen.filter(ligadto => ligadto.ligaVerantwortlichMail === this.currentUserService.getEmail());
+            this.handleLoadTableRows(filtered);
+          }
+        })
+        .catch(() => this.handleLoadTableRowsFailure(null));
   }
 
   private handleLoadTableRowsFailure(response: BogenligaResponse<LigaDTO[]>): void {
     this.rows = [];
-    this.loading = false;
-  }
-
-  private handleLoadTableRowsSuccess(response: BogenligaResponse<LigaDTO[]>): void {
-    this.rows = []; // reset array to ensure change detection
-    this.rows = toTableRows(response.payload);
     this.loading = false;
   }
 

--- a/bogenliga/src/app/modules/verwaltung/components/liga/liga-overview/liga-overview.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/liga/liga-overview/liga-overview.component.ts
@@ -41,6 +41,10 @@ export class LigaOverviewComponent extends CommonComponentDirective implements O
 
   private sessionHandling: SessionHandling;
 
+  // Gecachtes Admin-Flag: die Rolle des aktuellen Nutzers ändert sich innerhalb einer Session nicht,
+  // daher nur einmal laden und bei Folgerenderings (v.a. Quicksearch) wiederverwenden. (Review BSAPP-2191)
+  private isAdmin: boolean | null = null;
+
   constructor(
     private userDataProviderService: UserDataProviderService,
     private ligaDataProvider: LigaDataProviderService,
@@ -129,20 +133,30 @@ export class LigaOverviewComponent extends CommonComponentDirective implements O
    * die Berechtigungen nicht umgehen kann (BSAPP-2191).
    */
   private renderLigenForCurrentUser(ligen: LigaDTO[]): void {
+    // Admin-Flag nur beim ersten Aufruf laden, danach das gecachte Ergebnis nutzen –
+    // vermeidet einen Rollen-Request pro Suche (Quicksearch feuert mehrfach). (Review BSAPP-2191)
+    if (this.isAdmin !== null) {
+      this.renderLigenFiltered(ligen, this.isAdmin);
+      return;
+    }
     this.userDataProviderService.findUserRoleById(this.currentUserService.getCurrentUserID())
         .then((roleresponse: BogenligaResponse<UserRolleDO[]>) => {
-          const isAdmin = roleresponse.payload.filter(role => role.roleName == 'ADMIN').length > 0;
-          if (isAdmin) {
-            this.handleLoadTableRows(ligen);
-          } else {
-            const filtered = ligen.filter(ligadto => ligadto.ligaVerantwortlichMail === this.currentUserService.getEmail());
-            this.handleLoadTableRows(filtered);
-          }
+          this.isAdmin = roleresponse.payload.filter(role => role.roleName == 'ADMIN').length > 0;
+          this.renderLigenFiltered(ligen, this.isAdmin);
         })
-        .catch(() => this.handleLoadTableRowsFailure(null));
+        .catch(() => this.handleLoadTableRowsFailure());
   }
 
-  private handleLoadTableRowsFailure(response: BogenligaResponse<LigaDTO[]>): void {
+  private renderLigenFiltered(ligen: LigaDTO[], isAdmin: boolean): void {
+    if (isAdmin) {
+      this.handleLoadTableRows(ligen);
+    } else {
+      const filtered = ligen.filter(ligadto => ligadto.ligaVerantwortlichMail === this.currentUserService.getEmail());
+      this.handleLoadTableRows(filtered);
+    }
+  }
+
+  private handleLoadTableRowsFailure(response?: BogenligaResponse<LigaDTO[]>): void {
     this.rows = [];
     this.loading = false;
   }


### PR DESCRIPTION
In der Ligen-Uebersicht sah ein Ligaleiter ueber das Suchfeld alle Ligen, obwohl die normale Uebersicht nur die eigenen (Nicht-Admin-Filter ueber ligaVerantwortlichMail) zeigt. Ursache: findBySearch() rief handleLoadTableRowsSuccess ohne den Permission-Filter auf.

Uebersicht und Suche laufen jetzt durch dieselbe Logik (renderLigenForCurrentUser): Admins sehen alles, Nicht-Admins nur die Ligen, fuer die sie verantwortlich sind. Die redundante handleLoadTableRowsSuccess wurde entfernt.

Cypress-Test (Admin-Kontrolle positiv, Ligaleiter negativ) ergaenzt.