### PR TITLE
swt2#2185: Wettkampftage-Limit konsistent anzeigen (Neu/Kopieren deak…

### DIFF
--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/admin-user/wettkampftage-max-limit.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/admin-user/wettkampftage-max-limit.cy.js
@@ -1,0 +1,56 @@
+/**
+ * BSAPP-2185 — "Wettkampftag hinzufügen" bei erreichter Maximalanzahl
+ *
+ * Analyse-Ergebnis: Das Fehlen der "Neu"-Funktion liegt NICHT an der Veranstaltungs-Phase,
+ * sondern am Limit `MaxWettkampfTage` (configuration id 8, Default 4). Ist die maximale Anzahl
+ * an Wettkampftagen erreicht, wurde "Neu" bisher nur beim Klick per Fehlermeldung abgewiesen
+ * (wirkt wie ein Bug/inkonsistent).
+ *
+ * Fix: "Neu"/"Kopieren" werden bei erreichtem Limit deaktiviert und ein Hinweis wird angezeigt.
+ *
+ * Testdaten (LOCAL-DB, MaxWettkampfTage=4):
+ *  - Veranstaltung 0 ("Würtembergliga"): 5 Wettkampftage -> Limit erreicht (Hinweis + "Neu" disabled)
+ *  - Veranstaltung 1102 (1 Wettkampftag): unter dem Limit ("Neu" aktiv, kein Hinweis)
+ *
+ * Der Limit-Check ist benutzerunabhängig; als Admin ist jede Veranstaltung erreichbar.
+ */
+
+const VERANSTALTUNG_AT_LIMIT = 0;
+const VERANSTALTUNG_UNDER_LIMIT = 1102;
+
+function openWettkampftage(id) {
+  cy.visit(`http://localhost:4200/#/verwaltung/veranstaltung/${id}/${id}`);
+  // cy.visit erkennt einen reinen Hash-Wechsel (gleiche URL vor '#') NICHT als Reload -> Angular
+  // würde die Wettkampftage-Komponente wiederverwenden (Zustands-Übernahme zwischen Tests).
+  // cy.reload() erzwingt einen echten vollständigen Reload mit frischer Komponente.
+  cy.reload();
+  cy.get('bla-wettkampftage', {timeout: 20000}).should('exist');
+}
+
+describe('BSAPP-2185: Wettkampftage-Limit blendet "Neu"/"Kopieren" konsistent aus', () => {
+
+  before(() => {
+    cy.loginAdmin();
+    cy.url({timeout: 20000}).should('include', '/home');
+    cy.wait(1500);
+  });
+
+  it('positiv: bei erreichtem Limit ist "Neu" deaktiviert und der Hinweis wird angezeigt', () => {
+    openWettkampftage(VERANSTALTUNG_AT_LIMIT);
+
+    // Hinweis erscheint, sobald anzahl >= Max geladen ist.
+    cy.get('[data-cy=wettkampftage-max-hint]', {timeout: 20000}).should('be.visible');
+    // "Neu" und "Kopieren" sind deaktiviert.
+    cy.contains('bla-actionbutton', 'Neu').find('button').should('be.disabled');
+    cy.contains('bla-actionbutton', 'Kopieren').find('button').should('be.disabled');
+  });
+
+  it('negativ: unter dem Limit ist "Neu" aktiv und es erscheint kein Hinweis', () => {
+    openWettkampftage(VERANSTALTUNG_UNDER_LIMIT);
+    cy.wait(3000); // Daten laden lassen
+
+    // Unter dem Limit: kein Hinweis, "Neu" ist aktiv.
+    cy.get('[data-cy=wettkampftage-max-hint]').should('not.exist');
+    cy.contains('bla-actionbutton', 'Neu').find('button', {timeout: 20000}).should('not.be.disabled');
+  });
+});

--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/admin-user/wettkampftage-max-limit.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/admin-user/wettkampftage-max-limit.cy.js
@@ -48,7 +48,7 @@ describe('BSAPP-2185: Wettkampftage-Limit blendet "Neu"/"Kopieren" konsistent au
 
   it('negativ: unter dem Limit ist "Neu" aktiv und es erscheint kein Hinweis', () => {
     openWettkampftage(VERANSTALTUNG_UNDER_LIMIT);
-    cy.wait(3000); // Daten laden lassen
+    cy.get('[data-cy=wettkampftage-datum]', {timeout: 20000}).invoke('val').should('match', /^\d{4}-\d{2}-\d{2}$/);
 
     // Unter dem Limit: kein Hinweis, "Neu" ist aktiv.
     cy.get('[data-cy=wettkampftage-max-hint]').should('not.exist');

--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/admin-user/wettkampftage-max-limit.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/admin-user/wettkampftage-max-limit.cy.js
@@ -42,8 +42,8 @@ describe('BSAPP-2185: Wettkampftage-Limit blendet "Neu"/"Kopieren" konsistent au
     // Hinweis erscheint, sobald anzahl >= Max geladen ist.
     cy.get('[data-cy=wettkampftage-max-hint]', {timeout: 20000}).should('be.visible');
     // "Neu" und "Kopieren" sind deaktiviert.
-    cy.contains('bla-actionbutton', 'Neu').find('button').should('be.disabled');
-    cy.contains('bla-actionbutton', 'Kopieren').find('button').should('be.disabled');
+    cy.contains('bla-actionbutton', 'Neu', {timeout: 20000}).find('button').should('be.disabled');
+    cy.contains('bla-actionbutton', 'Kopieren', {timeout: 20000}).find('button').should('be.disabled');
   });
 
   it('negativ: unter dem Limit ist "Neu" aktiv und es erscheint kein Hinweis', () => {

--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/admin-user/wettkampftage-max-limit.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/admin-user/wettkampftage-max-limit.cy.js
@@ -25,6 +25,7 @@ function openWettkampftage(id) {
   // cy.reload() erzwingt einen echten vollständigen Reload mit frischer Komponente.
   cy.reload();
   cy.get('bla-wettkampftage', {timeout: 20000}).should('exist');
+  cy.get('[data-cy=wettkampftage-datum]', {timeout: 20000}).invoke('val').should('match', /^\d{4}-\d{2}-\d{2}$/);
 }
 
 describe('BSAPP-2185: Wettkampftage-Limit blendet "Neu"/"Kopieren" konsistent aus', () => {

--- a/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/wettkampftage/wettkampftage.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/wettkampftage/wettkampftage.component.html
@@ -269,14 +269,6 @@
             {{ 'MANAGEMENT.VERANSTALTUNG_DETAIL.FORM.WETTKAMPFTAG.NOTIFICATION.COPY.TITLE' | translate }}
           </bla-actionbutton>
 
-          <!-- HINWEIS: MAXIMALE ANZAHL WETTKAMPFTAGE ERREICHT (BSAPP-2185) -->
-          <p *ngIf="entityExists() && isMaxWettkampftageReached()"
-             data-cy="wettkampftage-max-hint"
-             class="wettkampftage-max-hint">
-            {{ 'MANAGEMENT.VERANSTALTUNG_DETAIL.FORM.WETTKAMPFTAG.FORM.MAXREACHED' | translate }}
-            ({{ getMaxWettkampftageCount() }})
-          </p>
-
           <!-- SPEICHERN -->
           <bla-actionbutton (onClick)="onSaveWettkampfTag(selectedWettkampfTag, $event); wettkampftageForm.form.markAsPristine();"
                             [disabled]="(wettkampftageStrasse.invalid || wettkampftagePLZ.invalid || wettkampftageOrt.invalid  || wettkampftageBeginn.invalid || wettkampftageDatum.invalid)"
@@ -290,6 +282,14 @@
 
 
         </div>
+
+        <!-- HINWEIS: MAXIMALE ANZAHL WETTKAMPFTAGE ERREICHT (BSAPP-2185) -->
+        <p *ngIf="entityExists() && isMaxWettkampftageReached()"
+           data-cy="wettkampftage-max-hint"
+           class="wettkampftage-max-hint">
+          {{ 'MANAGEMENT.VERANSTALTUNG_DETAIL.FORM.WETTKAMPFTAG.FORM.MAXREACHED' | translate }}
+          ({{ getMaxWettkampftageCount() }})
+        </p>
 
 
         <div class="form-group row">

--- a/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/wettkampftage/wettkampftage.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/wettkampftage/wettkampftage.component.html
@@ -252,7 +252,7 @@
           <!-- NEU: WETTKAMPFTAG HINZUFÜGEN -->
           <bla-actionbutton (onClick)="onAddWettkampfTag($event)"
                             *ngIf="entityExists()"
-                            [disabled]="wettkampftageForm.dirty"
+                            [disabled]="wettkampftageForm.dirty || isMaxWettkampftageReached()"
                             [loading]="saveLoading"
                             [color]="ActionButtonColors.SUCCESS"
                             [iconClass]="'plus'">
@@ -261,13 +261,21 @@
 
           <!-- WETTKAMPFTAG KOPIEREN -->
           <bla-actionbutton *ngIf="entityExists()"
-                            [disabled]="wettkampftageForm.dirty"
+                            [disabled]="wettkampftageForm.dirty || isMaxWettkampftageReached()"
                             [loading]="saveLoading"
                             [color]="ActionButtonColors.SUCCESS"
                             [iconClass]="'copy'"
                             (onClick)="onCopyWettkampfTag($event)">
             {{ 'MANAGEMENT.VERANSTALTUNG_DETAIL.FORM.WETTKAMPFTAG.NOTIFICATION.COPY.TITLE' | translate }}
           </bla-actionbutton>
+
+          <!-- HINWEIS: MAXIMALE ANZAHL WETTKAMPFTAGE ERREICHT (BSAPP-2185) -->
+          <p *ngIf="entityExists() && isMaxWettkampftageReached()"
+             data-cy="wettkampftage-max-hint"
+             class="wettkampftage-max-hint">
+            {{ 'MANAGEMENT.VERANSTALTUNG_DETAIL.FORM.WETTKAMPFTAG.FORM.MAXREACHED' | translate }}
+            ({{ getMaxWettkampftageCount() }})
+          </p>
 
           <!-- SPEICHERN -->
           <bla-actionbutton (onClick)="onSaveWettkampfTag(selectedWettkampfTag, $event); wettkampftageForm.form.markAsPristine();"

--- a/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/wettkampftage/wettkampftage.component.scss
+++ b/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/wettkampftage/wettkampftage.component.scss
@@ -9,6 +9,14 @@
   flex-wrap: wrap;
 }
 
+// Hinweis, wenn die maximale Anzahl an Wettkampftagen erreicht ist (BSAPP-2185)
+.wettkampftage-max-hint {
+  width: 100%;
+  margin-top: 0.5rem;
+  color: #856404;
+  font-size: 0.9rem;
+}
+
 
 // for small devices
 @media (max-width: 1400px) {

--- a/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/wettkampftage/wettkampftage.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/wettkampftage/wettkampftage.component.ts
@@ -911,6 +911,21 @@ export class WettkampftageComponent extends CommonComponentDirective implements 
     return configuredMaxWettkampftage;
   }
 
+  /** Für das Template: konfigurierte Maximalanzahl an Wettkampftagen (BSAPP-2185). */
+  public getMaxWettkampftageCount(): number {
+    return this.getMaxWettkampftage();
+  }
+
+  /**
+   * True, wenn die maximale Anzahl an Wettkampftagen erreicht ist. Steuert im Template das
+   * Deaktivieren von "Neu"/"Kopieren" und den Hinweistext, damit für den Nutzer klar ist,
+   * dass das Limit greift (statt eines vermeintlichen Bugs). Nutzt dieselbe Zählgröße wie die
+   * Anlege-Prüfung in createInitWettkampfTag/copyCurrentWettkampfTag. (BSAPP-2185)
+   */
+  public isMaxWettkampftageReached(): boolean {
+    return this.anzahl >= this.getMaxWettkampftage();
+  }
+
   private getNextWettkampftagNumber(): number {
     if (isNullOrUndefined(this.selectedDTOs) || this.selectedDTOs.length === 0) {
       return 1;

--- a/bogenliga/src/assets/i18n/de.json
+++ b/bogenliga/src/assets/i18n/de.json
@@ -1479,6 +1479,7 @@
           "FORM": {
             "LABEL": "Wettkampftag",
             "REMINDSAVE": "Bitte speichern Sie zuerst Ihre Änderungen.",
+            "MAXREACHED": "Maximale Anzahl an Wettkampftagen erreicht",
             "DATUM": {
               "LABEL": "Datum",
               "PLACEHOLDER": "Datum",

--- a/bogenliga/src/assets/i18n/en.json
+++ b/bogenliga/src/assets/i18n/en.json
@@ -1582,6 +1582,7 @@
             "FORM": {
               "LABEL": "Competition day",
               "REMINDSAVE": "Please save your changes first.",
+              "MAXREACHED": "Maximum number of competition days reached",
               "DATUM": {
                 "LABEL": "date",
                 "PLACEHOLDER": "date",


### PR DESCRIPTION
…tivieren + Hinweis)

Analyse: Das Fehlen der Neu-Funktion bei einzelnen Veranstaltungen liegt nicht an der Phase, sondern am Limit MaxWettkampfTage (configuration id 8, Default 4). Bei erreichter Maximalanzahl wurde Neu bisher nur beim Klick per Fehlermeldung abgewiesen, was wie ein Bug/inkonsistent wirkte.

Fix: Bei erreichtem Limit werden die Buttons Neu und Kopieren deaktiviert und ein Hinweis (Maximale Anzahl an Wettkampftagen erreicht (N)) angezeigt. Neue Helfer isMaxWettkampftageReached()/getMaxWettkampftageCount(), i18n-Key MAXREACHED (de/en).

Cypress-Test (positiv: Limit erreicht -> Neu disabled + Hinweis; negativ: unter Limit -> Neu aktiv, kein Hinweis).