### PR TITLE
swt2#2179: Klare Fehlermeldung beim Download von Rueckennummern/Lizen…

### DIFF
--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/admin-user/download-leere-mannschaft.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/admin-user/download-leere-mannschaft.cy.js
@@ -1,0 +1,78 @@
+/**
+ * BSAPP-2179 — Klare Fehlermeldung beim Download von Rückennummern/Lizenzen einer leeren Mannschaft
+ *
+ * Vorher: Download für eine Mannschaft ohne Mitglieder erzeugte im Backend einen unverständlichen
+ * Fehler (Rückennummern: IndexOutOfBounds -> 500; Lizenzen: leeres/kaputtes PDF). Es war keine
+ * verständliche Meldung definiert.
+ *
+ * Fix: Vor dem Download wird geprüft, ob die Mannschaft Mitglieder hat. Ist sie leer, erscheint
+ * eine klare Meldung ("Die Mannschaft enthält keine Mitglieder ...") und der Download wird NICHT
+ * ausgeführt.
+ *
+ * Da lokal keine leere Mannschaft existiert, wird die Mitglieder-Antwort per cy.intercept gestubbt
+ * (sicher, ohne echte Daten zu ändern). Testdaten: Verein 0, Mannschaft 101.
+ */
+
+const VEREIN_ID = 0;
+const MANNSCHAFT_ID = 101;
+const EMPTY_HINT = 'keine Mitglieder';
+
+function openVereinDetail() {
+  cy.visit(`http://localhost:4200/#/verwaltung/vereine/${VEREIN_ID}`);
+  cy.get(`#payload-id-${MANNSCHAFT_ID}`, {timeout: 20000}).should('exist');
+}
+
+describe('BSAPP-2179: Download leerer Mannschaft zeigt klare Meldung', () => {
+
+  beforeEach(() => {
+    cy.loginAdmin();
+    cy.url({timeout: 20000}).should('include', '/home');
+    cy.wait(1000);
+  });
+
+  afterEach(() => {
+    // Offene Notification schließen, damit ihr Overlay nicht den Login des nächsten Tests verdeckt
+    // (testIsolation ist aus, Hash-Navigation lädt die App nicht neu).
+    cy.get('body').then(($b) => {
+      if ($b.find('#OKBtn1').length) {
+        cy.get('#OKBtn1 button', {timeout: 5000}).click({force: true});
+      }
+    });
+  });
+
+  it('positiv: Rückennummern-Download einer leeren Mannschaft zeigt die klare Meldung', () => {
+    cy.intercept('GET', `**/v1/mannschaftsmitglied/${MANNSCHAFT_ID}`, {statusCode: 200, body: []}).as('members');
+
+    openVereinDetail();
+    cy.get(`#payload-id-${MANNSCHAFT_ID} [data-cy="TABLE.ACTIONS.DOWNLOADRUECKENNUMMER"]`).first().click();
+
+    cy.wait('@members');
+    cy.get('bla-notification', {timeout: 20000}).contains(EMPTY_HINT).should('be.visible');
+  });
+
+  it('positiv: Lizenzen-Download einer leeren Mannschaft zeigt die klare Meldung', () => {
+    cy.intercept('GET', `**/v1/mannschaftsmitglied/${MANNSCHAFT_ID}`, {statusCode: 200, body: []}).as('members');
+
+    openVereinDetail();
+    cy.get(`#payload-id-${MANNSCHAFT_ID} [data-cy="TABLE.ACTIONS.DOWNLOADLIZENZEN"]`).first().click();
+
+    cy.wait('@members');
+    cy.get('bla-notification', {timeout: 20000}).contains(EMPTY_HINT).should('be.visible');
+  });
+
+  it('negativ: bei einer Mannschaft mit Mitgliedern erscheint die Leer-Meldung NICHT', () => {
+    // Mannschaft hat Mitglieder -> Download läuft normal weiter (Download-Endpoint gestubbt).
+    cy.intercept('GET', `**/v1/mannschaftsmitglied/${MANNSCHAFT_ID}`, {
+      statusCode: 200,
+      body: [{id: 1, mannschaftId: MANNSCHAFT_ID, dsbMitgliedId: 1, rueckennummer: 1, version: 0}]
+    }).as('members');
+    cy.intercept('GET', '**/v1/download/pdf/rueckennummern*', {statusCode: 200, body: 'PDF'}).as('dl');
+
+    openVereinDetail();
+    cy.get(`#payload-id-${MANNSCHAFT_ID} [data-cy="TABLE.ACTIONS.DOWNLOADRUECKENNUMMER"]`).first().click();
+
+    cy.wait('@members');
+    cy.wait(1500);
+    cy.get('bla-notification').contains(EMPTY_HINT).should('not.exist');
+  });
+});

--- a/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/verein/verein-detail/verein-detail.component.ts
@@ -45,6 +45,7 @@ import {UserRolleDO} from '@verwaltung/types/user-rolle-do.class';
 import {LigaDataProviderService} from '@verwaltung/services/liga-data-provider.service';
 import {TableActionType} from '@shared/components/tables/types/table-action-type.enum';
 import {WettkampfDataProviderService} from '@verwaltung/services/wettkampf-data-provider.service';
+import {MannschaftsmitgliedDataProviderService} from '@verwaltung/services/mannschaftsmitglied-data-provider.service';
 import {WettkampfDTO} from '@verwaltung/types/datatransfer/wettkampf-dto.class';
 
 const ID_PATH_PARAM = 'id';
@@ -58,6 +59,7 @@ const NOTIFICATION_COPY_MANNSCHAFT = 'mannschaft_detail_copy';
 const NOTIFICATION_DELETE_MANNSCHAFT_SUCCESS = 'mannschaft_detail_delete_success';
 const NOTIFICATION_DELETE_MANNSCHAFT_FAILURE = 'mannschaft_detail_delete_failure';
 const NOTIFICATION_NO_LICENSE = 'no_license_found';
+const NOTIFICATION_EMPTY_MANNSCHAFT = 'download_empty_mannschaft';
 const NOTIFICATION_DOWNLOAD_BEFORE_DEADLINE = 'download_before_deadline';
 const NOTIFICATION_ENTITY_CONFLICT_ERROR = 'ENTITY_CONFLICT_ERROR';
 const NOTIFICATION_DATABASE_ERROR = 'DATABASE_ERROR';
@@ -107,7 +109,8 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
     private notificationService: NotificationService,
     private userDataProviderService: UserDataProviderService,
     private ligaProvider: LigaDataProviderService,
-    private wettkampfDataProviderService: WettkampfDataProviderService,) {
+    private wettkampfDataProviderService: WettkampfDataProviderService,
+    private mannschaftsmitgliedProvider: MannschaftsmitgliedDataProviderService,) {
     super();
     this.sessionHandling = new SessionHandling(this.currentUserService, this.onOfflineService);
   }
@@ -439,20 +442,62 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
       return;
     }
     if (!this.onOfflineService.isOffline()) {
-      const URL: string = new UriBuilder()
-        .fromPath(environment.backendBaseUrl)
-        .path('v1/download')
-        .path('pdf/rueckennummern')
-        .path('?mannschaftid=' + versionedDataObject.id)
-        .build();
-      this.downloadService.download(URL, 'rueckennummern.pdf', this.aElementRef)
-          .then((response: BogenligaResponse<string>) => console.log(response))
-          .catch((response: BogenligaResponse<string>) => console.log(response));
+      // Leere Mannschaft vorab abfangen -> sonst liefert das Backend einen unverständlichen
+      // Fehler (keine Mitglieder). (BSAPP-2179)
+      this.withNonEmptyMannschaft(versionedDataObject.id, () => this.performDownloadRueckennummer(versionedDataObject));
     } else {
       console.log('offline');
       this.returnMatch(versionedDataObject);
     }
 
+  }
+
+  private performDownloadRueckennummer(versionedDataObject: VersionedDataObject): void {
+    const URL: string = new UriBuilder()
+      .fromPath(environment.backendBaseUrl)
+      .path('v1/download')
+      .path('pdf/rueckennummern')
+      .path('?mannschaftid=' + versionedDataObject.id)
+      .build();
+    this.downloadService.download(URL, 'rueckennummern.pdf', this.aElementRef)
+        .then((response: BogenligaResponse<string>) => console.log(response))
+        .catch((response: BogenligaResponse<string>) => console.log(response));
+  }
+
+  /**
+   * Prüft, ob die Mannschaft Mitglieder hat. Ist sie leer, wird eine klare Meldung angezeigt und
+   * der Download NICHT ausgeführt. Bei nicht leeren Mannschaften (oder falls die Prüfung selbst
+   * fehlschlägt) wird der eigentliche Download über den Callback gestartet. (BSAPP-2179)
+   */
+  private withNonEmptyMannschaft(mannschaftId: number, onNonEmpty: () => void): void {
+    this.mannschaftsmitgliedProvider.findAllByTeamId(mannschaftId)
+        .then((response) => {
+          if (isNullOrUndefined(response.payload) || response.payload.length === 0) {
+            this.showEmptyMannschaftNotification();
+          } else {
+            onNonEmpty();
+          }
+        })
+        .catch(() => onNonEmpty());
+  }
+
+  private showEmptyMannschaftNotification(): void {
+    const notification: Notification = {
+      id:          NOTIFICATION_EMPTY_MANNSCHAFT,
+      title:       'MANAGEMENT.VEREIN_DETAIL.NOTIFICATION.EMPTY_MANNSCHAFT.TITLE',
+      description: 'MANAGEMENT.VEREIN_DETAIL.NOTIFICATION.EMPTY_MANNSCHAFT.DESCRIPTION',
+      severity:    NotificationSeverity.ERROR,
+      origin:      NotificationOrigin.USER,
+      type:        NotificationType.OK,
+      userAction:  NotificationUserAction.PENDING
+    };
+    this.notificationService.observeNotification(NOTIFICATION_EMPTY_MANNSCHAFT)
+        .subscribe((myNotification) => {
+          if (myNotification.userAction === NotificationUserAction.ACCEPTED) {
+            this.saveLoading = false;
+          }
+        });
+    this.notificationService.showNotification(notification);
   }
 
   // Get match Info from offlineDB
@@ -503,6 +548,11 @@ export class VereinDetailComponent extends CommonComponentDirective implements O
        this.showBeforeDeadlineNotification();
        return;
      }
+     // Leere Mannschaft vorab abfangen -> sonst wird ein leeres/unverständliches PDF erzeugt. (BSAPP-2179)
+     this.withNonEmptyMannschaft(versionedDataObject.id, () => this.performDownloadLizenzen(versionedDataObject));
+   }
+
+   private performDownloadLizenzen(versionedDataObject: VersionedDataObject): void {
     const URL: string = new UriBuilder()
        .fromPath(environment.backendBaseUrl)
        .path('v1/download')

--- a/bogenliga/src/assets/i18n/de.json
+++ b/bogenliga/src/assets/i18n/de.json
@@ -1073,6 +1073,10 @@
           "TITLE": "Fehler beim Download",
           "DESCRIPTION": "Der Lizenzenübersicht konnte nicht heruntergeladen werden, da eine oder mehreren Lizenzen nicht vorhanden sind."
         },
+        "EMPTY_MANNSCHAFT": {
+          "TITLE": "Download nicht möglich",
+          "DESCRIPTION": "Die Mannschaft enthält keine Mitglieder. Rückennummern und Lizenzen können daher nicht heruntergeladen werden."
+        },
         "DOWNLOAD_BEFORE_DEADLINE": {
           "TITLE": "Download nicht verfügbar",
           "DESCRIPTION": "Der Download ist erst nach Ablauf der Meldedeadline möglich."

--- a/bogenliga/src/assets/i18n/en.json
+++ b/bogenliga/src/assets/i18n/en.json
@@ -1086,6 +1086,10 @@
           "DOWNLOAD_BEFORE_DEADLINE": {
             "TITLE": "Download not available",
             "DESCRIPTION": "The download is only available after the registration deadline has passed."
+          },
+          "EMPTY_MANNSCHAFT": {
+            "TITLE": "Download not possible",
+            "DESCRIPTION": "The team has no members. Therefore, bib numbers and licences cannot be downloaded."
           }
         },
         "NOTIFICATION_PLATZHALTER": {


### PR DESCRIPTION
…zen leerer Mannschaften

Beim Download fuer eine Mannschaft ohne Mitglieder gab es keine verstaendliche Meldung: das Backend warf einen unklaren Fehler (Rueckennummern: IndexOutOfBounds -> 500) bzw. erzeugte ein leeres PDF (Lizenzen); im Frontend wurde bei Rueckennummern nur console.log ausgefuehrt.

Fix: Vor dem Download wird per findAllByTeamId geprueft, ob die Mannschaft Mitglieder hat. Ist sie leer, erscheint eine klare Meldung (neuer i18n-Key EMPTY_MANNSCHAFT, de/en) und der Download wird nicht ausgefuehrt - fuer Rueckennummern und Lizenzen.

Cypress-Test mit positiver und negativer Assertion (leere Mannschaft per cy.intercept gestubbt).