### PR TITLE
swt2#2158: Verstaendliche Fehlermeldung bei 'Mannschaften aus Vorjahr…

### DIFF
--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/admin-user/mannschaften-vorjahr-kopieren.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/admin-user/mannschaften-vorjahr-kopieren.cy.js
@@ -1,0 +1,75 @@
+/**
+ * BSAPP-2158 — "Mannschaften aus Vorjahr kopieren": verständliche Fehlermeldung
+ *
+ * Vorher: Schlug der eigentliche Kopier-Aufruf fehl, gab es KEINE lokale Meldung (nur console.log)
+ * -> der globale Error-Interceptor zeigte die generische, unverständliche Meldung
+ * "Ihre Anfrage wurde vom Server abgewiesen".
+ *
+ * Fix: (1) Der Interceptor umgeht das globale Handling für die Copy-Endpoints
+ * (findLastVeranstaltungBy / byLastVeranstaltungsID). (2) Die Komponente zeigt bei Copy-Fehler eine
+ * eigene, verständliche Meldung ("Die Mannschaften konnten nicht aus dem Vorjahr kopiert werden ...").
+ *
+ * Der Fehlerfall wird per cy.intercept deterministisch erzeugt (Vorjahr existiert -> findLast 200,
+ * Copy-Aufruf -> HTTP 400), ohne echte Daten zu verändern.
+ * Testdaten: Veranstaltung 3 (geplant, groesse 8, keine Mannschaften -> Copy-Button aktiv).
+ */
+
+const VERANSTALTUNG_ID = 3;
+const COPY_BUTTON_TEXT = 'Mannschaften aus Vorjahr';
+const GENERIC_MSG = 'vom Server abgewiesen';
+const CLEAR_MSG = 'konnten nicht'; // aus COPYMANNSCHAFT_FAILURE_GENERAL
+
+function stubPreviousYearExistsButCopyFails() {
+  // Vorjahr existiert (groesse <= aktuelle 8 -> kein Sizediff, es wird kopiert)
+  cy.intercept('GET', '**/v1/veranstaltung/findLastVeranstaltungBy/*', {
+    statusCode: 200,
+    body: {id: 999, wettkampfTypId: 0, name: 'Vorjahr Test', sportjahr: 2017, ligaleiterId: 1, ligaId: 9, version: 0, groesse: 1, phase: 'Geplant'}
+  }).as('findLast');
+  // Der eigentliche Kopier-Aufruf schlaegt fehl (400 = "vom Server abgewiesen" im Altverhalten)
+  cy.intercept('GET', '**/v1/dsbmannschaft/byLastVeranstaltungsID/*/*', {
+    statusCode: 400,
+    body: {errorCode: 'INVALID_ARGUMENT_ERROR', errorMessage: 'x', param: null}
+  }).as('copy');
+}
+
+function openVeranstaltungAndClickCopy() {
+  cy.visit(`http://localhost:4200/#/verwaltung/veranstaltung/${VERANSTALTUNG_ID}`);
+  cy.contains('bla-actionbutton', COPY_BUTTON_TEXT, {timeout: 20000})
+    .find('button')
+    .click({force: true});
+  cy.wait('@findLast');
+  cy.wait('@copy');
+}
+
+describe('BSAPP-2158: Mannschaften aus Vorjahr kopieren zeigt verständliche Meldung', () => {
+
+  beforeEach(() => {
+    cy.loginAdmin();
+    cy.url({timeout: 20000}).should('include', '/home');
+    cy.wait(1000);
+  });
+
+  afterEach(() => {
+    // Offene Notification schließen, damit ihr Overlay nicht den Login des nächsten Tests verdeckt.
+    cy.get('body').then(($b) => {
+      if ($b.find('#OKBtn1').length) {
+        cy.get('#OKBtn1 button', {timeout: 5000}).click({force: true});
+      }
+    });
+  });
+
+  it('positiv: bei fehlgeschlagenem Kopieren erscheint eine verständliche Meldung', () => {
+    stubPreviousYearExistsButCopyFails();
+    openVeranstaltungAndClickCopy();
+
+    cy.get('bla-notification', {timeout: 20000}).contains(CLEAR_MSG).should('be.visible');
+  });
+
+  it('negativ: die generische "vom Server abgewiesen"-Meldung erscheint NICHT', () => {
+    stubPreviousYearExistsButCopyFails();
+    openVeranstaltungAndClickCopy();
+    cy.wait(1500);
+
+    cy.get('bla-notification').contains(GENERIC_MSG).should('not.exist');
+  });
+});

--- a/bogenliga/src/app/modules/shared/data-provider/interceptors/error-interceptor.class.ts
+++ b/bogenliga/src/app/modules/shared/data-provider/interceptors/error-interceptor.class.ts
@@ -35,6 +35,13 @@ export class ErrorInterceptor implements HttpInterceptor {
                        return throwError(error);
                      }
 
+                     // Bypass global error handling for "Mannschaften aus Vorjahr kopieren": die Komponente
+                     // zeigt eigene, verständliche Meldungen (kein Vorjahr vorhanden / Kopieren fehlgeschlagen)
+                     // statt der generischen "Ihre Anfrage wurde vom Server abgewiesen"-Meldung. (BSAPP-2158)
+                     if (request.url.includes('findLastVeranstaltungBy') || request.url.includes('byLastVeranstaltungsID')) {
+                       return throwError(error);
+                     }
+
                      // handle connection (0), client (4xx), server (5xx) and custom error codes (9xx)
                      // if it is a connection error, it could be a masked error indicated by an expired session token
                      // this is very likely, so the user should be routed to the login-site again and

--- a/bogenliga/src/app/modules/shared/data-provider/interceptors/error-interceptor.class.ts
+++ b/bogenliga/src/app/modules/shared/data-provider/interceptors/error-interceptor.class.ts
@@ -35,12 +35,14 @@ export class ErrorInterceptor implements HttpInterceptor {
                        return throwError(error);
                      }
 
-                     // Bypass global error handling for "Mannschaften aus Vorjahr kopieren": die Komponente
-                     // zeigt eigene, verständliche Meldungen (kein Vorjahr vorhanden / Kopieren fehlgeschlagen)
-                     // statt der generischen "Ihre Anfrage wurde vom Server abgewiesen"-Meldung. (BSAPP-2158)
-                     if (request.url.includes('findLastVeranstaltungBy') || request.url.includes('byLastVeranstaltungsID')) {
-                       return throwError(error);
-                     }
+                      // Bypass global error handling for "Mannschaften aus Vorjahr kopieren": die Komponente
+                      // zeigt eigene, verständliche Meldungen (kein Vorjahr vorhanden / Kopieren fehlgeschlagen)
+                      // statt der generischen "Ihre Anfrage wurde vom Server abgewiesen"-Meldung. (BSAPP-2158)
+                      // Wichtig: Session-Expiry (Status 0/401) muss weiterhin global behandelt werden.
+                      if ((request.url.includes('findLastVeranstaltungBy') || request.url.includes('byLastVeranstaltungsID'))
+                        && !(error && (error.status === 0 || error.status === 401))) {
+                        return throwError(error);
+                      }
 
                      // handle connection (0), client (4xx), server (5xx) and custom error codes (9xx)
                      // if it is a connection error, it could be a masked error indicated by an expired session token

--- a/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/veranstaltung-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/veranstaltung-detail.component.ts
@@ -62,6 +62,7 @@ const NOTIFICATION_INIT_LIGATABELLE_SUC = 'init_Ligatabelle_suc';
 const NOTIFICATION_INIT_LIGATABELLE_FAIL = 'init_Ligatabelle_fail';
 const NOTIFICATION_COPY_MANNSCHAFTEN_FAILURE = 'veranstaltung_detail_copy_failure';
 const NOTIFICATION_COPY_MANNSCHAFTEN_FAILURE_SIZEDIFF = 'veranstaltung_detail_copy_failure_sizediff';
+const NOTIFICATION_COPY_MANNSCHAFTEN_FAILURE_GENERAL = 'veranstaltung_detail_copy_failure_general';
 const NOTIFICATION_FINISH_VERANSTALTUNG = 'veranstaltung_detail_finish';
 const NOTIFICATION_CREATE_PLATZHALTER = 'platzhalter_create';
 const NOTIFICATION_CREATE_PLATZHALTER_FAILURE = 'platzhalter_create_failure';
@@ -431,6 +432,8 @@ export class VeranstaltungDetailComponent extends CommonComponentDirective imple
             , () => {
               console.log('Failed');
               this.saveLoading = false;
+              // Verständliche Meldung statt der generischen Server-Fehlermeldung. (BSAPP-2158)
+              this.showCopyMannschaftGeneralFailureNotification();
             });
       }
       )
@@ -453,6 +456,30 @@ export class VeranstaltungDetailComponent extends CommonComponentDirective imple
           });
         this.notificationService.showNotification(notification);
       });
+  }
+
+  /**
+   * Zeigt eine verständliche Meldung, wenn das Kopieren der Mannschaften aus dem Vorjahr
+   * fehlschlägt (z.B. Server-/Berechtigungsfehler). Ersetzt die generische
+   * "Ihre Anfrage wurde vom Server abgewiesen"-Meldung. (BSAPP-2158)
+   */
+  private showCopyMannschaftGeneralFailureNotification(): void {
+    const notification: Notification = {
+      id:          NOTIFICATION_COPY_MANNSCHAFTEN_FAILURE_GENERAL,
+      title:       'MANAGEMENT.VERANSTALTUNG_DETAIL.NOTIFICATION.COPYMANNSCHAFT_FAILURE_GENERAL.TITLE',
+      description: 'MANAGEMENT.VERANSTALTUNG_DETAIL.NOTIFICATION.COPYMANNSCHAFT_FAILURE_GENERAL.DESCRIPTION',
+      severity:    NotificationSeverity.ERROR,
+      origin:      NotificationOrigin.USER,
+      type:        NotificationType.OK,
+      userAction:  NotificationUserAction.PENDING
+    };
+    this.notificationService.observeNotification(NOTIFICATION_COPY_MANNSCHAFTEN_FAILURE_GENERAL)
+      .subscribe((myNotification) => {
+        if (myNotification.userAction === NotificationUserAction.ACCEPTED) {
+          this.saveLoading = false;
+        }
+      });
+    this.notificationService.showNotification(notification);
   }
 
 

--- a/bogenliga/src/assets/i18n/de.json
+++ b/bogenliga/src/assets/i18n/de.json
@@ -1581,12 +1581,16 @@
           "DESCRIPTION": "Es existiert in diesem Sportjahr bereits eine Veranstaltung für die von Ihnen angegebenen Liga. Bitte überprüfen Sie Ihre Eingabe."
         },
         "COPYMANNSCHAFT_FAILURE": {
-          "TITLE": "Kopieren fehlgeschlagen",
-          "DESCRIPTION": "Keine Veranstaltung im Vorjahr vorhanden"
+          "TITLE": "Kopieren nicht möglich",
+          "DESCRIPTION": "Es existiert keine Veranstaltung aus dem Vorjahr (gleiche Liga und Wettkampftyp), aus der Mannschaften kopiert werden können."
         },
         "COPYMANNSCHAFT_FAILURE_SIZEDIFF": {
           "TITLE": "Kopieren fehlgeschlagen",
           "DESCRIPTION": "Veranstaltung im Vorjahr hat eine andere Anzahl an Mannschaften."
+        },
+        "COPYMANNSCHAFT_FAILURE_GENERAL": {
+          "TITLE": "Kopieren fehlgeschlagen",
+          "DESCRIPTION": "Die Mannschaften konnten nicht aus dem Vorjahr kopiert werden. Bitte versuchen Sie es erneut oder wenden Sie sich an einen Administrator."
         },
         "UPDATE": {
           "TITLE": "Aktualisieren erfolgreich",

--- a/bogenliga/src/assets/i18n/en.json
+++ b/bogenliga/src/assets/i18n/en.json
@@ -1520,12 +1520,16 @@
                 "DESCRIPTION": "Successfully initialized league table"
               },
               "COPYMANNSCHAFT_FAILURE": {
-                "TITLE": "Copy failed",
-                "DESCRIPTION": "No Event from last year"
+                "TITLE": "Copy not possible",
+                "DESCRIPTION": "There is no event from the previous year (same league and competition type) from which teams could be copied."
               },
               "COPYMANNSCHAFT_FAILURE_SIZEDIFF": {
                 "TITLE": "Copy failed",
                 "DESCRIPTION": "Event from last year has a different amount of Teams"
+              },
+              "COPYMANNSCHAFT_FAILURE_GENERAL": {
+                "TITLE": "Copy failed",
+                "DESCRIPTION": "The teams could not be copied from the previous year. Please try again or contact an administrator."
               },
               "FAILURE": {
                 "TITLE": "Error while initializing",

--- a/bogenliga/src/assets/i18n/en.json
+++ b/bogenliga/src/assets/i18n/en.json
@@ -1519,18 +1519,6 @@
                 "TITLE": "Success",
                 "DESCRIPTION": "Successfully initialized league table"
               },
-              "COPYMANNSCHAFT_FAILURE": {
-                "TITLE": "Copy not possible",
-                "DESCRIPTION": "There is no event from the previous year (same league and competition type) from which teams could be copied."
-              },
-              "COPYMANNSCHAFT_FAILURE_SIZEDIFF": {
-                "TITLE": "Copy failed",
-                "DESCRIPTION": "Event from last year has a different amount of Teams"
-              },
-              "COPYMANNSCHAFT_FAILURE_GENERAL": {
-                "TITLE": "Copy failed",
-                "DESCRIPTION": "The teams could not be copied from the previous year. Please try again or contact an administrator."
-              },
               "FAILURE": {
                 "TITLE": "Error while initializing",
                 "DESCRIPTION": "Could not initialize league table"
@@ -1648,6 +1636,18 @@
           "ADD": {
             "TITLE": "Add competition day",
             "DESCRIPTION": "Do you want to add another competition day?"
+          },
+          "COPYMANNSCHAFT_FAILURE": {
+            "TITLE": "Copy not possible",
+            "DESCRIPTION": "There is no event from the previous year (same league and competition type) from which teams could be copied."
+          },
+          "COPYMANNSCHAFT_FAILURE_SIZEDIFF": {
+            "TITLE": "Copy failed",
+            "DESCRIPTION": "Event from last year has a different amount of Teams"
+          },
+          "COPYMANNSCHAFT_FAILURE_GENERAL": {
+            "TITLE": "Copy failed",
+            "DESCRIPTION": "The teams could not be copied from the previous year. Please try again or contact an administrator."
           },
           "FINISH": {
             "TITLE": "Finish event",


### PR DESCRIPTION
… kopieren'

Schlug das Kopieren fehl (z.B. kein Vorjahr / Copy-Aufruf-Fehler), zeigte der globale Error-Interceptor nur die generische Meldung 'Ihre Anfrage wurde vom Server abgewiesen'; der Copy-Fehler-Pfad hatte gar keine lokale Meldung.

Fix: (1) Der Error-Interceptor umgeht das globale Handling fuer die Copy-Endpoints (findLastVeranstaltungBy / byLastVeranstaltungsID). (2) Die Komponente zeigt bei Copy-Fehler eine eigene, verstaendliche Meldung (neuer i18n-Key COPYMANNSCHAFT_FAILURE_GENERAL, de/en); die 'kein Vorjahr'-Meldung wurde ebenfalls klarer formuliert.

Cypress-Test (positiv: klare Meldung erscheint; negativ: generische Meldung erscheint nicht); Fehlerfall per cy.intercept erzeugt.