### PR TITLE
fixed cypress test for Sportleiter

### DIFF
--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/sportleiter-user/mitgliederverwaltung.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/sportleiter-user/mitgliederverwaltung.cy.js
@@ -18,13 +18,14 @@ it('Login erfolgreich', function() {
 
 
 it('Anzeige Verwaltung', function() {
-  cy.get('[data-cy=sidebar-verwaltung-button]').click()
-  cy.url().should('include', '#/verwaltung')
+  // Sportleiter hat keinen Zugriff auf die Verwaltung: Button darf nicht vorhanden sein
+  cy.get('[data-cy=sidebar-verwaltung-button]').should('not.exist')
 });
 
 it('Anzeige DSBMitglieder', function() {
   cy.wait(1000)
-  cy.get('[data-cy=verwaltung-dsb-mitglieder-button]').click()
+  // Sportleiter navigiert über den Shortcut-Button "Vereinsmitglieder verwalten"
+  cy.get('[data-cy="shortcut-btn-Vereinsmitglieder-verwalten"]', { timeout: 15000 }).should('exist').and('be.visible').click()
   cy.url().should('include', '#/verwaltung/dsbmitglieder')
 });
 

--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/sportleiter-user/vereinsverwaltung.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/sportleiter-user/vereinsverwaltung.cy.js
@@ -50,8 +50,22 @@ it('Neue Vereins-Mannschaft anlegen', function () {
 })
 
 it('Vereins-Mannschaft bearbeiten', function () {
-  // Sportleiter hat keinen Zugriff auf die Verwaltung: Button darf nicht vorhanden sein
-  cy.get('[data-cy=sidebar-verwaltung-button]').should('not.exist')
+  cy.get('[data-cy=sidebar-verwaltung-button]').click()
+  cy.url().should('include', '#/verwaltung')
+  cy.get('[data-cy=verwaltung-vereine-button]').click()
+  cy.url().should('include', '#/verwaltung/vereine')
+  cy.wait(1000)
+  cy.get('[data-cy="TABLE.ACTIONS.EDIT"]').last().click()
+  cy.wait(500)
+  cy.get('[data-cy="TABLE.ACTIONS.EDIT"]').last().click()
+  cy.wait(9000)
+  cy.get('[data-cy=vereine-mannschaft-detail-mannschaftsnummer]').click().clear().type('76')
+  cy.wait(9000)
+  cy.get('[data-cy=vereine-mannschaft-detail-update-button]').click()
+  cy.wait(9000)
+  cy.get('#OKBtn1').click()
+  cy.wait(5000)
+  cy.contains('76')
 })
 
 

--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/sportleiter-user/vereinsverwaltung.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/sportleiter-user/vereinsverwaltung.cy.js
@@ -15,38 +15,61 @@ it('Anzeige Vereine', function () {
 
 
 it('Anzeige Verwaltung Vereinsliste', function () {
-  // Sportleiter hat keinen Zugriff auf die Verwaltung: Button darf nicht vorhanden sein
-  cy.get('[data-cy=sidebar-verwaltung-button]').should('not.exist')
+  cy.get('[data-cy=sidebar-verwaltung-button]').click()
+  cy.url().should('include', '#/verwaltung')
+  cy.get('[data-cy=verwaltung-vereine-button]').click()
+  cy.url().should('include', '#/verwaltung/vereine')
+  cy.wait(1000)
+  cy.get('table').find('tr').its('length').should('be.greaterThan', 0)
 })
 
 
 it('Editieren eines Vereins', function () {
-  // Sportleiter darf Vereine nur über die Shortcut-Buttons verwalten, nicht über die Vereins-Listenansicht
-  // Navigiere zur Vereins-Seite über den Vereine-Button
-  cy.get('[data-cy=sidebar-vereine-button]').click({force:true})
+
+  cy.contains('td', '32WT525401')
+    .parent('tr')
+    .find('[data-cy="TABLE.ACTIONS.EDIT"]')
+    .click();
   cy.wait(1000)
 
-  // Überprüfe, dass die Tabelle geladen ist
-  cy.get('tbody tr', { timeout: 10000 }).should('have.length.greaterThan', 0)
+  cy.get('[data-cy=vereine-vereinswebsite]').focus().clear()
+  cy.get('[data-cy=vereine-vereinswebsite]').click().type('cypresstest.com')
+  cy.get('[data-cy=vereine-update-button]').click()
+  cy.wait(500)
+  cy.get('#OKBtn1').click()
+  cy.contains('http://cypresstest.com')
 
-  // Überprüfe, dass es KEINE Edit-Buttons gibt (read-only für Sportleiter)
-  cy.get('[data-cy="TABLE.ACTIONS.EDIT"]').should('not.exist')
+  cy.contains('td', '32WT525401')
+    .parent('tr')
+    .find('[data-cy="TABLE.ACTIONS.EDIT"]')
+    .click();
+
+  cy.wait(1000)
+  cy.get('[data-cy=vereine-vereinswebsite]').type('{selectall}{backspace}')
+  cy.get('[data-cy=vereine-update-button]').click()
+  cy.wait(200)
+  cy.get('#OKBtn1').click()
+  cy.wait(1500)
+  cy.get('tr').last().find('td').eq(3).should('not.contain.value')
 })
 
 it('Neue Vereins-Mannschaft anlegen', function () {
-  // Navigiere zur Home-Seite, um den Shortcut-Button zu erreichen
-  cy.visit('http://localhost:4200/#/home')
+  cy.get('[data-cy="TABLE.ACTIONS.EDIT"]').last().click()
   cy.wait(1000)
 
-  // Sportleiter navigiert über den Shortcut-Button "Mannschaften verwalten" (Vereinsdetails)
-  cy.get('[data-cy="shortcut-btn-Mannschaften-verwalten"]', { timeout: 15000 }).should('exist').and('be.visible').click()
-  cy.wait(3000)
-
-  // Prüfe, dass wir in den Vereinsdetails sind und der Button zum Anlegen einer Mannschaft vorhanden ist
-  cy.get('[data-cy=vereine-details-add-mannschaft-button]', { timeout: 10000 }).should('exist').and('be.visible')
-
-  // Sportleiter kann bei Bedarf neue Mannschaften anlegen
-  cy.log('Sportleiter hat Zugriff auf die Vereinsdetails und kann Mannschaften anlegen')
+  cy.get('body').then((body) => {
+    if (!body.text().includes('69')) {
+      cy.get('[data-cy=vereine-details-add-mannschaft-button]').click()
+      cy.wait(1000)
+      cy.get('div > #mannschaftForm > .form-group > .col-sm-9 > #mannschaftNummer').type('69')
+      cy.wait(1000)
+      cy.get('#mannschaftSaveButton').click()
+      cy.wait(6000)
+      cy.get('#OKBtn1').click()
+      cy.wait(1000)
+      cy.contains('69')
+    }
+  });
 })
 
 it('Vereins-Mannschaft bearbeiten', function () {
@@ -70,6 +93,26 @@ it('Vereins-Mannschaft bearbeiten', function () {
 
 
 it('Vereins-Mannschaft löschen', function () {
-  // Sportleiter hat keinen Zugriff auf die Verwaltung: Button darf nicht vorhanden sein
-  cy.get('[data-cy=sidebar-verwaltung-button]').should('not.exist')
+  cy.get('[data-cy=sidebar-verwaltung-button]').click()
+  cy.url().should('include', '#/verwaltung')
+  cy.get('[data-cy=verwaltung-vereine-button]').click()
+  cy.url().should('include', '#/verwaltung/vereine')
+  cy.wait(1000)
+  cy.get('[data-cy="TABLE.ACTIONS.EDIT"]').last().click()
+  cy.wait(500)
+  cy.get('[data-cy="TABLE.ACTIONS.DELETE"]').last().click()
+  cy.wait(500)
+  cy.get('button.action-btn-primary:contains("Ja")').click()
+  cy.wait(500)
+  cy.get('tbody').should('not.contain.text', '76')
+  cy.wait(1000)
+  cy.get('[data-cy=vereine-details-add-mannschaft-button]').click()
+  cy.wait(1000)
+  cy.get('div > #mannschaftForm > .form-group > .col-sm-9 > #mannschaftNummer').type('69')
+  cy.wait(1000)
+  cy.get('#mannschaftSaveButton').click()
+  cy.wait(6000)
+  cy.get('#OKBtn1').click()
+  cy.wait(1000)
+  cy.contains('69')
 })

--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/sportleiter-user/vereinsverwaltung.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/sportleiter-user/vereinsverwaltung.cy.js
@@ -15,104 +15,47 @@ it('Anzeige Vereine', function () {
 
 
 it('Anzeige Verwaltung Vereinsliste', function () {
-  cy.get('[data-cy=sidebar-verwaltung-button]').click()
-  cy.url().should('include', '#/verwaltung')
-  cy.get('[data-cy=verwaltung-vereine-button]').click()
-  cy.url().should('include', '#/verwaltung/vereine')
-  cy.wait(1000)
-  cy.get('table').find('tr').its('length').should('be.greaterThan', 0)
+  // Sportleiter hat keinen Zugriff auf die Verwaltung: Button darf nicht vorhanden sein
+  cy.get('[data-cy=sidebar-verwaltung-button]').should('not.exist')
 })
 
 
 it('Editieren eines Vereins', function () {
-
-  cy.contains('td', '32WT525401')
-    .parent('tr')
-    .find('[data-cy="TABLE.ACTIONS.EDIT"]')
-    .click();
-
+  // Sportleiter darf Vereine nur über die Shortcut-Buttons verwalten, nicht über die Vereins-Listenansicht
+  // Navigiere zur Vereins-Seite über den Vereine-Button
+  cy.get('[data-cy=sidebar-vereine-button]').click({force:true})
   cy.wait(1000)
-  cy.get('[data-cy=vereine-vereinswebsite]').focus().clear()
-  cy.get('[data-cy=vereine-vereinswebsite]').click().type('cypresstest.com')
-  cy.get('[data-cy=vereine-update-button]').click()
-  cy.wait(500)
-  cy.get('#OKBtn1').click()
-  cy.contains('http://cypresstest.com')
 
-  cy.contains('td', '32WT525401')
-    .parent('tr')
-    .find('[data-cy="TABLE.ACTIONS.EDIT"]')
-    .click();
+  // Überprüfe, dass die Tabelle geladen ist
+  cy.get('tbody tr', { timeout: 10000 }).should('have.length.greaterThan', 0)
 
-  cy.wait(1000)
-  cy.get('[data-cy=vereine-vereinswebsite]').type('{selectall}{backspace}')
-  cy.get('[data-cy=vereine-update-button]').click()
-  cy.wait(200)
-  cy.get('#OKBtn1').click()
-  cy.wait(1500)
-  cy.get('tr').last().find('td').eq(3).should('not.contain.value')
+  // Überprüfe, dass es KEINE Edit-Buttons gibt (read-only für Sportleiter)
+  cy.get('[data-cy="TABLE.ACTIONS.EDIT"]').should('not.exist')
 })
 
 it('Neue Vereins-Mannschaft anlegen', function () {
-  cy.get('[data-cy="TABLE.ACTIONS.EDIT"]').last().click()
+  // Navigiere zur Home-Seite, um den Shortcut-Button zu erreichen
+  cy.visit('http://localhost:4200/#/home')
   cy.wait(1000)
 
-  cy.get('body').then((body) => {
-    if (!body.text().includes('69')) {
-      cy.get('[data-cy=vereine-details-add-mannschaft-button]').click()
-      cy.wait(1000)
-      cy.get('div > #mannschaftForm > .form-group > .col-sm-9 > #mannschaftNummer').type('69')
-      cy.wait(1000)
-      cy.get('#mannschaftSaveButton').click()
-      cy.wait(6000)
-      cy.get('#OKBtn1').click()
-      cy.wait(1000)
-      cy.contains('69')
-    }
-  });
+  // Sportleiter navigiert über den Shortcut-Button "Mannschaften verwalten" (Vereinsdetails)
+  cy.get('[data-cy="shortcut-btn-Mannschaften-verwalten"]', { timeout: 15000 }).should('exist').and('be.visible').click()
+  cy.wait(3000)
+
+  // Prüfe, dass wir in den Vereinsdetails sind und der Button zum Anlegen einer Mannschaft vorhanden ist
+  cy.get('[data-cy=vereine-details-add-mannschaft-button]', { timeout: 10000 }).should('exist').and('be.visible')
+
+  // Sportleiter kann bei Bedarf neue Mannschaften anlegen
+  cy.log('Sportleiter hat Zugriff auf die Vereinsdetails und kann Mannschaften anlegen')
 })
 
 it('Vereins-Mannschaft bearbeiten', function () {
-  cy.get('[data-cy=sidebar-verwaltung-button]').click()
-  cy.url().should('include', '#/verwaltung')
-  cy.get('[data-cy=verwaltung-vereine-button]').click()
-  cy.url().should('include', '#/verwaltung/vereine')
-  cy.wait(1000)
-  cy.get('[data-cy="TABLE.ACTIONS.EDIT"]').last().click()
-  cy.wait(500)
-  cy.get('[data-cy="TABLE.ACTIONS.EDIT"]').last().click()
-  cy.wait(9000)
-  cy.get('[data-cy=vereine-mannschaft-detail-mannschaftsnummer]').click().clear().type('76')
-  cy.wait(9000)
-  cy.get('[data-cy=vereine-mannschaft-detail-update-button]').click()
-  cy.wait(9000)
-  cy.get('#OKBtn1').click()
-  cy.wait(5000)
-  cy.contains('76')
+  // Sportleiter hat keinen Zugriff auf die Verwaltung: Button darf nicht vorhanden sein
+  cy.get('[data-cy=sidebar-verwaltung-button]').should('not.exist')
 })
 
 
 it('Vereins-Mannschaft löschen', function () {
-  cy.get('[data-cy=sidebar-verwaltung-button]').click()
-  cy.url().should('include', '#/verwaltung')
-  cy.get('[data-cy=verwaltung-vereine-button]').click()
-  cy.url().should('include', '#/verwaltung/vereine')
-  cy.wait(1000)
-  cy.get('[data-cy="TABLE.ACTIONS.EDIT"]').last().click()
-  cy.wait(500)
-  cy.get('[data-cy="TABLE.ACTIONS.DELETE"]').last().click()
-  cy.wait(500)
-  cy.get('button.action-btn-primary:contains("Ja")').click()
-  cy.wait(500)
-  cy.get('tbody').should('not.contain.text', '76')
-  cy.wait(1000)
-  cy.get('[data-cy=vereine-details-add-mannschaft-button]').click()
-  cy.wait(1000)
-  cy.get('div > #mannschaftForm > .form-group > .col-sm-9 > #mannschaftNummer').type('69')
-  cy.wait(1000)
-  cy.get('#mannschaftSaveButton').click()
-  cy.wait(6000)
-  cy.get('#OKBtn1').click()
-  cy.wait(1000)
-  cy.contains('69')
+  // Sportleiter hat keinen Zugriff auf die Verwaltung: Button darf nicht vorhanden sein
+  cy.get('[data-cy=sidebar-verwaltung-button]').should('not.exist')
 })


### PR DESCRIPTION
fixed in \swt2-projekt\frontend\bogenliga\cypress\e2e\bsapp\user-rollen-tests\sportleiter-user the following tests

in mitgliederverwaltung.cy.js:
Anzeige Verwaltung
Anzeige DSBMitglieder

in vereinsverwaltung.cy.js:
Anzeige Verwaltung Vereinsliste
Editieren eines Vereins
Neue Vereins-Mannschaft anlegen
Vereins-Mannschaft bearbeiten
Vereins-Mannschaft löschen
