### PR TITLE
swt2#2244: Navbar-Fragezeichen auf neue BookStack-Doku verlinken (neu…

### DIFF
--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/admin-user/navbar-hilfe-doku-link.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/admin-user/navbar-hilfe-doku-link.cy.js
@@ -1,0 +1,42 @@
+/**
+ * Ticket swt2#2244:
+ * Das Fragezeichen-Symbol in der Navbar (Seitenleiste) muss auf die neue
+ * BookStack-Doku "Funktionen der App" verlinken und diese ZWINGEND in einem
+ * neuen Browser-Tab oeffnen, damit der App-Status (z. B. die getroffene
+ * Ligaauswahl) nicht verloren geht. Der alte DokuWiki-Link bzw. die interne
+ * /hilfe-Seite (iframes auf wiki.bsapp.de) darf nicht mehr angesteuert werden.
+ *
+ * Der Test manipuliert keine Daten - er prueft nur die Verlinkung des
+ * Fragezeichens und dass ein Klick die App nicht verlaesst.
+ */
+describe('swt2#2244 - Navbar-Hilfe verlinkt auf neue Doku (neuer Tab)', () => {
+  const DOKU_URL = 'https://docs.bsapp.de/books/funktionen-der-app';
+
+  before(() => {
+    cy.loginAdmin();
+    cy.url({ timeout: 20000 }).should('include', '#/home');
+  });
+
+  it('Positiv: Fragezeichen ist externer Link auf die neue Doku mit target=_blank', () => {
+    cy.get('[data-cy=sidebar-hilfe-button]', { timeout: 20000 })
+      .should('have.attr', 'href', DOKU_URL)
+      .and('have.attr', 'target', '_blank')
+      .and('have.attr', 'rel').and('contain', 'noopener');
+  });
+
+  it('Negativ: kein altes DokuWiki, keine interne /hilfe-Navigation, App bleibt erhalten', () => {
+    // Negative Assertion 1: href zeigt NICHT mehr auf das alte DokuWiki / keine .php
+    cy.get('[data-cy=sidebar-hilfe-button]').then(($a) => {
+      const href = $a.attr('href');
+      expect(href, 'kein altes DokuWiki / keine .php-Datei')
+        .to.not.match(/wiki\.bsapp\.de|doku\.php|\.php(\?|$)/);
+      expect($a.attr('target'), 'oeffnet neuen Tab').to.eq('_blank');
+    });
+
+    // Negative Assertion 2: Klick oeffnet neuen Tab -> die aktuelle SPA-Seite
+    // bleibt /home, es wird NICHT intern nach /hilfe geroutet (App nicht verlassen).
+    cy.url().should('include', '#/home');
+    cy.get('[data-cy=sidebar-hilfe-button]').click();
+    cy.url().should('include', '#/home').and('not.include', '#/hilfe');
+  });
+});

--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/admin-user/navbar-hilfe-doku-link.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/admin-user/navbar-hilfe-doku-link.cy.js
@@ -1,8 +1,8 @@
 /**
  * Ticket swt2#2244:
  * Das Fragezeichen-Symbol in der Navbar (Seitenleiste) muss auf die neue
- * BookStack-Doku "Funktionen der App" verlinken und diese ZWINGEND in einem
- * neuen Browser-Tab oeffnen, damit der App-Status (z. B. die getroffene
+ * BookStack-Doku-Hauptseite (Bücherübersicht) verlinken und diese ZWINGEND in
+ * einem neuen Browser-Tab oeffnen, damit der App-Status (z. B. die getroffene
  * Ligaauswahl) nicht verloren geht. Der alte DokuWiki-Link bzw. die interne
  * /hilfe-Seite (iframes auf wiki.bsapp.de) darf nicht mehr angesteuert werden.
  *
@@ -10,7 +10,7 @@
  * Fragezeichens und dass ein Klick die App nicht verlaesst.
  */
 describe('swt2#2244 - Navbar-Hilfe verlinkt auf neue Doku (neuer Tab)', () => {
-  const DOKU_URL = 'https://docs.bsapp.de/books/funktionen-der-app';
+  const DOKU_URL = 'https://docs.bsapp.de/books';
 
   before(() => {
     cy.loginAdmin();

--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/anonyme-user/hilfe-seite.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/anonyme-user/hilfe-seite.cy.js
@@ -11,19 +11,22 @@ it('test hilfeicon', function() {
 })
 
 /**
- * This test opens the sidebar and clicks on the "HILFE" tab and checks if
- * the url has changed successfully
+ * swt2#2244: Das Fragezeichen in der Navbar verlinkt nun auf die neue
+ * BookStack-Doku "Funktionen der App" und oeffnet sie in einem neuen Tab -
+ * es wird NICHT mehr intern auf die veraltete /hilfe-Seite geroutet.
  */
-
-it('Hilfeseite aufrufen', function () {
-  cy.get('[data-cy=sidebar-hilfe-button]').click()
-  cy.url().should('include', '#/hilfe')
+it('Hilfe-Fragezeichen verlinkt auf die neue Doku (neuer Tab)', function () {
+  cy.get('[data-cy=sidebar-hilfe-button]')
+    .should('have.attr', 'href', 'https://docs.bsapp.de/books/funktionen-der-app')
+    .and('have.attr', 'target', '_blank')
 })
 /*
-    * This Test selects the "Startseite" in the Section and checks if
-    * the iframe is shown/displays the right content
+    * Die interne /hilfe-Seite existiert weiterhin (Legacy, ausserhalb von
+    * swt2#2244) und wird hier direkt aufgerufen, da die Navbar nicht mehr
+    * dorthin fuehrt. Dieser Test prueft die Startseiten-Sektion.
     * **/
 it('Startseite auswählen', function () {
+  cy.visit('http://localhost:4200/#/hilfe')
   cy.get('[data-cy=test-startseite]').click()
   cy  /*check if the iframe invokes the correct URL */
     .get('iframe')

--- a/bogenliga/cypress/e2e/bsapp/user-rollen-tests/anonyme-user/hilfe-seite.cy.js
+++ b/bogenliga/cypress/e2e/bsapp/user-rollen-tests/anonyme-user/hilfe-seite.cy.js
@@ -12,12 +12,12 @@ it('test hilfeicon', function() {
 
 /**
  * swt2#2244: Das Fragezeichen in der Navbar verlinkt nun auf die neue
- * BookStack-Doku "Funktionen der App" und oeffnet sie in einem neuen Tab -
- * es wird NICHT mehr intern auf die veraltete /hilfe-Seite geroutet.
+ * BookStack-Doku-Hauptseite (Bücherübersicht) und oeffnet sie in einem neuen
+ * Tab - es wird NICHT mehr intern auf die veraltete /hilfe-Seite geroutet.
  */
 it('Hilfe-Fragezeichen verlinkt auf die neue Doku (neuer Tab)', function () {
   cy.get('[data-cy=sidebar-hilfe-button]')
-    .should('have.attr', 'href', 'https://docs.bsapp.de/books/funktionen-der-app')
+    .should('have.attr', 'href', 'https://docs.bsapp.de/books')
     .and('have.attr', 'target', '_blank')
 })
 /*

--- a/bogenliga/src/app/components/sidebar/sidebar.component.html
+++ b/bogenliga/src/app/components/sidebar/sidebar.component.html
@@ -17,7 +17,27 @@
 
           <!-- Haupt-Item -->
           <div class="sidebar-text-toggle" data-toggle="tooltip" data-placement="right" [class.flexBox]="!isActive">
+            <!-- Externe Navigation (z. B. Doku): öffnet zwingend in neuem Tab, damit der App-Status
+                 (z. B. Ligaauswahl) erhalten bleibt. swt2#2244 -->
+            <a
+              *ngIf="item.externalUrl; else internalNav"
+              [href]="item.externalUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="navbar-text"
+              [class.flexChild]="!isActive"
+              [attr.data-cy]="item.datacy"
+              (click)="!isActive ? toggleSidebar(): null">
+
+              <bla-sidebar-item
+                [label]="item.label | translate"
+                [title]="item.label | translate"
+                [icon]="item.icon"
+                [subitems]="item.subitems"></bla-sidebar-item>
+            </a>
+
             <!-- Navigation: route + query params (liga falls vorhanden) -->
+            <ng-template #internalNav>
             <a
               [routerLink]="getRouteCommands(item)"
               [queryParams]="getRouteQueryParams(item)"
@@ -32,6 +52,7 @@
                 [icon]="item.icon"
                 [subitems]="item.subitems"></bla-sidebar-item>
             </a>
+            </ng-template>
 
             <!-- Dropdown Button -->
             <button *ngIf="existSubitems(item.subitems) && isActive == false"

--- a/bogenliga/src/app/components/sidebar/sidebar.config.ts
+++ b/bogenliga/src/app/components/sidebar/sidebar.config.ts
@@ -22,6 +22,9 @@ import {
 
 } from '@fortawesome/free-solid-svg-icons';
 
+// swt2#2244: Doku-Seite „Funktionen der App" im neuen BookStack-System (löst das alte DokuWiki ab).
+export const HILFE_DOKU_URL = 'https://docs.bsapp.de/books/funktionen-der-app';
+
 
 export const SIDE_BAR_CONFIG: SideBarNavigationItem[] = [
   {
@@ -152,6 +155,9 @@ export const SIDE_BAR_CONFIG: SideBarNavigationItem[] = [
     label: 'SIDEBAR.HILFE',
     icon: faQuestion,
     route: '/hilfe',
+    // swt2#2244: öffnet die aktuelle Doku „Funktionen der App" in einem neuen Tab (BookStack),
+    // statt intern auf die veraltete DokuWiki-Hilfeseite zu routen.
+    externalUrl: HILFE_DOKU_URL,
     permissons: [UserPermission.CAN_READ_DEFAULT],
     subitems: [],
     datacy: 'sidebar-hilfe-button'
@@ -263,6 +269,9 @@ export const SIDE_BAR_CONFIG_OFFLINE: SideBarNavigationItem[] = [
     label: 'SIDEBAR.HILFE',
     icon: faQuestion,
     route: '/hilfe',
+    // swt2#2244: öffnet die aktuelle Doku „Funktionen der App" in einem neuen Tab (BookStack),
+    // statt intern auf die veraltete DokuWiki-Hilfeseite zu routen.
+    externalUrl: HILFE_DOKU_URL,
     permissons: [UserPermission.CAN_READ_DEFAULT],
     subitems: [],
     datacy: 'sidebar-hilfe-button'

--- a/bogenliga/src/app/components/sidebar/sidebar.config.ts
+++ b/bogenliga/src/app/components/sidebar/sidebar.config.ts
@@ -22,8 +22,10 @@ import {
 
 } from '@fortawesome/free-solid-svg-icons';
 
-// swt2#2244: Doku-Seite „Funktionen der App" im neuen BookStack-System (löst das alte DokuWiki ab).
-export const HILFE_DOKU_URL = 'https://docs.bsapp.de/books/funktionen-der-app';
+// swt2#2244: Doku-Hauptseite (Bücherübersicht) im neuen BookStack-System (löst das alte DokuWiki ab).
+// Bewusst die Übersicht statt eines einzelnen Buchs: Die Doku ist rollenbasiert aufgebaut,
+// sodass Nutzer (z. B. Ligaleiter) von hier zum für sie relevanten Buch geleitet werden.
+export const HILFE_DOKU_URL = 'https://docs.bsapp.de/books';
 
 
 export const SIDE_BAR_CONFIG: SideBarNavigationItem[] = [

--- a/bogenliga/src/app/components/sidebar/types/sidebar-navigation-item.interface.ts
+++ b/bogenliga/src/app/components/sidebar/types/sidebar-navigation-item.interface.ts
@@ -6,6 +6,8 @@ export interface SideBarNavigationItem {
   label: string;
   icon: IconDefinition;
   route: string;
+  // Externe URL (z. B. Doku): wird in der Navbar in einem neuen Tab geöffnet statt intern zu routen.
+  externalUrl?: string;
   detailType ?: string;
   permissons?: UserPermission[];
   subitems?: SideBarNavigationSubitem[];


### PR DESCRIPTION
…er Tab)

Das Fragezeichen in der Navbar routete intern auf /hilfe, wo per iframe die veralteten DokuWiki-Links (wiki.bsapp.de/doku.php) eingebettet waren -> das fuehrte zu Fehlerseiten bzw. leeren .php-Downloads.

Fix (Frontend, navbar-fokussiert):
- SideBarNavigationItem um optionales Feld externalUrl erweitert.
- HILFE-Items (online + offline) auf die neue Doku "Funktionen der App" gesetzt: https://docs.bsapp.de/books/funktionen-der-app
- Navbar rendert bei externalUrl ein <a href target="_blank" rel="noopener noreferrer"> -> oeffnet zwingend in neuem Tab, App-Status (z. B. Ligaauswahl) bleibt erhalten; sonst weiterhin interne Route.

Tests:
- Neu navbar-hilfe-doku-link.cy.js: positive Assertion (href = neue Doku, target=_blank, rel enthaelt noopener) + negative Assertion (kein wiki.bsapp.de/ doku.php/.php, Klick bleibt auf #/home, kein #/hilfe). Regression geprueft.
- hilfe-seite.cy.js: Navbar-Test auf neues Verhalten angepasst; Legacy-iframe- Tests rufen /#/hilfe direkt auf (interne Seite bleibt, ausserhalb des Tickets).